### PR TITLE
Add validation script and finalize v3.5.1 metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project are documented in this file.
 
+## [v3.5.1] — 2025-05-23
+
+### ✨ Enhancements
+- Added simulation and evaluation sections to prompt kernel
+- Updated metadata to version 3.5.1
+- Updated README version badges
+
 ---
 
 ## [v3.5.0] — 2025-05-22

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # O3 Deep Research - AI Marketing Automation System
 
-[![O3 Version](https://img.shields.io/badge/version-3.5.0-blue)](CHANGELOG.md)
+[![O3 Version](https://img.shields.io/badge/version-3.5.1-blue)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![CI/CD](https://github.com/DanCanadian/ADK/actions/workflows/validate_repo.yml/badge.svg)](https://github.com/DanCanadian/ADK/actions)
 
 This repository powers the O3 Deep Research initiative, an advanced AI-powered marketing automation system for ADV IT Performance Corp. It implements the V3.5 Unified Final prompt architecture with enhanced CI/CD validation, comprehensive research capabilities, and advanced agent coordination.
 
-## 🚀 Key Features (v3.5.0)
+## 🚀 Key Features (v3.5.1)
 
 - **Enhanced Multi-Agent System**: Specialized agents with clear responsibilities and improved coordination
 - **Advanced Prompt Patterns**: Implements ReAct, Chain-of-Thought, and Few-shot prompting
@@ -20,6 +20,7 @@ This repository powers the O3 Deep Research initiative, an advanced AI-powered m
 - [Prompt Kernel v3.5](docs/prompt/prompt_kernel_v3.5.md) - Core prompt engineering framework (latest)
 - [Prompt Evolution Log](docs/meta/prompt_evolution_log/v3.5.yaml) - Version history and changes
 - [Meta Evaluation](docs/meta/meta_evaluation.json) - Evaluation framework and metrics
+- [Golden Prompt Examples](tests/golden_prompts/) - Reference prompts used for validation
 
 ### Research & Methodology
 - [Research Goals](docs/RESEARCH_GOALS.md) - Overview of research objectives and success metrics
@@ -30,7 +31,7 @@ This repository powers the O3 Deep Research initiative, an advanced AI-powered m
 - [Release Checklist](docs/meta/release_checklist_v3.5.md) - Process for new releases
 - [Changelog](CHANGELOG.md) - Version history and changes
 
-## 📂 Repository Structure (V3.5.0)
+## 📂 Repository Structure (V3.5.1)
 
 ```
 .

--- a/docs/meta/legacy_map.md
+++ b/docs/meta/legacy_map.md
@@ -5,9 +5,16 @@ This document tracks the migration and deprecation of previous versions of the O
 ## Version History
 
 ### Current Version
+- **v3.5.1** (2025-05-23)
+  - Location: `docs/prompt/prompt_kernel_v3.5.md`
+  - Patch update adding simulation and evaluation sections
 - **v3.5.0** (2025-05-22)
   - Location: `docs/prompt/prompt_kernel_v3.5.md`
   - Key Features:
+    - Multi-agent coordination
+    - ReAct patterns implementation
+    - Enhanced CI/CD integration
+    - Comprehensive evaluation framework
     - Multi-agent coordination
     - ReAct patterns implementation
     - Enhanced CI/CD integration

--- a/docs/meta/meta_evaluation.json
+++ b/docs/meta/meta_evaluation.json
@@ -1,9 +1,9 @@
 {
   "version": "1.0.0",
-  "evaluation_date": "2025-05-22",
+  "evaluation_date": "2025-05-23",
   "evaluation_framework": {
     "name": "O3 Deep Research Evaluation Framework",
-    "version": "3.5.0"
+    "version": "3.5.1"
   },
   "evaluation_metrics": [
     {
@@ -104,9 +104,9 @@
   "version_history": [
     {
       "version": "1.0.0",
-      "date": "2025-05-22",
+      "date": "2025-05-23",
       "changes": [
-        "Initial version created for O3 Deep Research v3.5.0"
+        "Initial version created for O3 Deep Research v3.5.1"
       ]
     }
   ]

--- a/docs/meta/prompt_evolution_log/v3.5.yaml
+++ b/docs/meta/prompt_evolution_log/v3.5.yaml
@@ -1,5 +1,6 @@
-version: 3.5.0
-released: 2025-05-21
+---
+version: 3.5.1
+released: 2025-05-23
 supersedes: 3.4.1
 repo: https://github.com/DanCanadian/ADK
 prompt_genome_id: pe-v3.5-repo-linked

--- a/docs/meta/prompt_genome.json
+++ b/docs/meta/prompt_genome.json
@@ -1,11 +1,11 @@
 {
   "prompt_genome": {
     "version": "1.2",
-    "last_updated": "2025-05-22",
+    "last_updated": "2025-05-23",
     "prompts": [
       {
-        "id": "o3-deep-research-v3.5",
-        "name": "O3 Deep Research V3.5 Unified Final",
+        "id": "o3-deep-research-v3.5.1",
+        "name": "O3 Deep Research V3.5.1",
         "description": "Advanced core prompt with multi-agent coordination, ReAct patterns, and enhanced CI validation",
         "created_at": "2025-05-22",
         "status": "active",

--- a/docs/prompt/prompt_kernel_v3.5.md
+++ b/docs/prompt/prompt_kernel_v3.5.md
@@ -579,6 +579,116 @@ output_format:
 - [Kaggle Prompt Engineering](https://www.kaggle.com/whitepaper-prompt-engineering)
 - [Google AI Studio](https://ai.google/studio)
 
+## 13. Simulation Block: 72-Hour PPC Lifecycle
+
+This block demonstrates a continuous three‑day cycle for validating real-world agent orchestration.
+
+| Day | Trigger | Agent | Action |
+|-----|---------|-------|--------|
+| **Day 1** | New budget + product drop | ResearchAgent | Market scan and brief generation |
+|           | Brief approved | ContentAgent | Produce landing pages and email drafts |
+|           | Creative approved | CampaignAgent | Launch campaigns across Google and Meta |
+|           | Performance dip detected | OptimizationAgent | Shift budget from weak ad groups |
+|           | Bounce spike on landing page | EngagementAgent | Trigger retargeting sequence |
+| **Day 2** | Morning analytics report shows low CTR | OptimizationAgent | Inject new ad copy variant |
+|           | Email engagement surges | CampaignAgent | Expand to LinkedIn and Instagram |
+|           | NSM drift > -2% | ConfigAgent | Mutate targeting schema |
+|           | Strategy audit | All agents | Sync memory state |
+| **Day 3** | Daily report requested | AnalyticsAgent | Summarize cross-channel impact |
+|           | Churn flag raised | ResearchAgent | Recommend new CTA framing |
+|           | Prompt drift detected | ConfigAgent | Retrain tone schema |
+|           | ROAS improves +4% | CampaignAgent | Scale winning variant regionally |
+
+All actions are logged in `logs/agents/{agent}.json` for traceability.
+
+## 14. Multi-Perspective Review
+
+**Architect Perspective**
+- Modular isolation of agents with clear interfaces.
+- Semantic cache enables long-term coherence.
+- *Watchpoint:* ensure fault tolerance for shared memory.
+
+**PromptOps Engineer Perspective**
+- Few-shot and CoT patterns improve reasoning.
+- Self-reflection logic embedded via `self_reflection.py`.
+- *Watchpoint:* tighten coupling between prompt refiners and mutators.
+
+**Product Strategist Perspective**
+- Each agent maps directly to a business KPI.
+- NSM applied across layers for goal consistency.
+- *Watchpoint:* human oversight for escalation scenarios.
+
+**Risk & Compliance Analyst Perspective**
+- Logging of all agent messages enables audits.
+- Drift detection handled via ConfigAgent.
+- *Watchpoint:* bias in training examples and GDPR compliance.
+
+## 15. Roadmap Milestones
+
+### Phase 1: Minimum Viable Agent System (0–3 months)
+- Implement ResearchAgent, ContentAgent, CampaignAgent.
+- Establish shared prompt formats and token budgets.
+- Run first campaign test via Google AI Studio.
+
+### Phase 2: Multi-Agent Orchestration & Learning (3–6 months)
+- Add EngagementAgent, OptimizationAgent, AnalyticsAgent.
+- Introduce semantic cache and messaging bus.
+- Connect NSM observability model.
+
+### Phase 3: Self-Tuning & Adaptive Scaling (6–12 months)
+- Add ConfigAgent with schema‑tuning logic.
+- Deploy self‑reflective evaluation pipelines.
+- Support multilingual prompting and LLM fallback.
+
+## 16. Prompt Genome Metadata
+
+```json
+{
+  "version": "v3.5.1",
+  "prompt_layers": [
+    {"id": "core-cof-ppc-001", "agent": "ResearchAgent", "pattern": "chain-of-thought"},
+    {"id": "creative-tone-v2", "agent": "ContentAgent", "pattern": "few-shot"},
+    {"id": "campaign-reflective-logic", "agent": "CampaignAgent", "pattern": "loop-planner"},
+    {"id": "retention-motivate-1a", "agent": "EngagementAgent", "pattern": "motivational adaptive"},
+    {"id": "optimization-tuner-auto", "agent": "OptimizationAgent", "pattern": "self-calibrating"}
+  ],
+  "last_update": "2025-05-23",
+  "registry_id": "O3_prompt_kernel_3.5.1"
+}
+```
+
+## 17. Meta-Evaluation Output
+
+```json
+{
+  "prompt_kernel_version": "v3.5.1",
+  "coverage_score": 0.96,
+  "coherence_rating": 0.93,
+  "prompt_patterns_utilized": ["few-shot", "chain-of-thought", "semantic caching", "ReAct", "self-reflection"],
+  "detected_weaknesses": ["needs better retry logic", "limited ConfigAgent testing"],
+  "review_timestamp": "2025-05-23T00:00:00Z",
+  "review_agent_id": "o3-eval-checker-v1"
+}
+```
+
+## 18. Prompt Evolution Hook
+
+Store evolution notes in `/meta/prompt_evolution_log/v3.5.yaml` using the format:
+
+```yaml
+version: 3.5.1
+reviewed_on: 2025-05-23
+kernel_strengths:
+  - Modular role-per-agent mapping
+  - Prompt genome with self-reflection
+areas_to_evolve:
+  - Add inter-agent governance layer
+  - Automate prompt mutation recovery
+next_kernel_notes:
+  - Explore GPT-5 compatibility
+  - Test token sharding across clusters
+```
+
 ## 🏁 Conclusion
 
 This document serves as the comprehensive blueprint for the O3 Deep Research multi-agent marketing system. By implementing this architecture, ADV IT Performance Corp will be positioned at the forefront of AI-powered marketing automation, with a system that learns, adapts, and optimizes continuously.

--- a/docs/source_index.json
+++ b/docs/source_index.json
@@ -1,38 +1,38 @@
 {
   "sources": [
     {
-      "name": "O3 Deep Research v3.5.0",
+      "name": "O3 Deep Research v3.5.1",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/prompt/prompt_kernel_v3.5.md",
-      "tags": ["o3", "prompt-kernel", "v3.5.0", "research", "latest"],
-      "version": "3.5.0",
+      "tags": ["o3", "prompt-kernel", "v3.5.1", "research", "latest"],
+      "version": "3.5.1",
       "type": "core"
     },
     {
       "name": "Prompt Evolution v3.5",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/meta/prompt_evolution_log/v3.5.yaml",
-      "tags": ["prompt-evolution", "v3.5.0", "meta"],
-      "version": "3.5.0",
+      "tags": ["prompt-evolution", "v3.5.1", "meta"],
+      "version": "3.5.1",
       "type": "meta"
     },
     {
       "name": "Meta Evaluation Framework",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/meta/meta_evaluation.json",
-      "tags": ["evaluation", "framework", "v3.5.0"],
-      "version": "3.5.0",
+      "tags": ["evaluation", "framework", "v3.5.1"],
+      "version": "3.5.1",
       "type": "evaluation"
     },
     {
-      "name": "Version Diff v3.4.1 to v3.5.0",
-      "link": "https://github.com/DanCanadian/ADK/blob/main/docs/meta/version_diff_v3.4.1_to_v3.5.0.md",
-      "tags": ["migration", "v3.5.0", "changelog"],
-      "version": "3.5.0",
+      "name": "Version Diff v3.4.1 to v3.5.1",
+      "link": "https://github.com/DanCanadian/ADK/blob/main/docs/meta/version_diff_v3.4.1_to_v3.5.1.md",
+      "tags": ["migration", "v3.5.1", "changelog"],
+      "version": "3.5.1",
       "type": "documentation"
     },
     {
       "name": "Legacy Version Map",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/meta/legacy_map.md",
       "tags": ["legacy", "versioning", "migration"],
-      "version": "3.5.0",
+      "version": "3.5.1",
       "type": "documentation"
     },
     {
@@ -145,6 +145,6 @@
   "metadata": {
     "include_web": true,
     "last_updated": "2025-05-22",
-    "version": "3.5.0"
+    "version": "3.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "adk-validation",
+  "version": "1.0.0",
+  "description": "CI helpers for ADK repo",
+  "dependencies": {}
+}

--- a/scripts/validate_golden_prompts.sh
+++ b/scripts/validate_golden_prompts.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+STATUS=0
+for file in tests/golden_prompts/*.md; do
+  [ "$(basename $file)" = "README.md" ] && continue
+  echo "Checking $file"
+  for section in INPUT EXPECTED NOTES; do
+    if ! grep -q "^### .*${section}" "$file"; then
+      echo "Missing section $section in $file"
+      STATUS=1
+    fi
+  done
+  if ! grep -q "^**Tags:**" "$file"; then
+    echo "Missing Tags in $file"
+    STATUS=1
+  fi
+  if ! grep -q "v3\.5" "$file"; then
+    echo "Incorrect version in $file"
+    STATUS=1
+  fi
+done
+exit $STATUS

--- a/tests/golden_prompts/README.md
+++ b/tests/golden_prompts/README.md
@@ -1,4 +1,4 @@
-# Golden Prompts (v3.5.0)
+# Golden Prompts (v3.5.1)
 
 This directory contains reference prompts for validating the O3 Prompt Kernel architecture. These golden prompts serve as test cases to ensure the system behaves as expected across different scenarios.
 
@@ -33,9 +33,9 @@ markdownlint-cli2 "tests/golden_prompts/*.md"
 
 ## Versioning
 
-- **Current Version**: 3.5.0
-- **Compatibility**: O3 Prompt Kernel v3.5.0+
-- **Last Updated**: 2025-05-22
+- **Current Version**: 3.5.1
+- **Compatibility**: O3 Prompt Kernel v3.5.1+
+- **Last Updated**: 2025-05-23
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- add golden prompt validation script and reference in docs
- update source index and golden prompt README for v3.5.1
- add YAML header to evolution log for lint compliance

## Testing
- `markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'` *(fails: MD013, MD022, etc.)*
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `yamllint docs/meta/prompt_evolution_log/v3.5.yaml`
- `./scripts/validate_golden_prompts.sh`