### PR TITLE
Add updated golden prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project are documented in this file.
 
+## [v3.5.1] — 2025-05-23
+
+### ✨ Enhancements
+- Added simulation and evaluation sections to prompt kernel
+- Updated metadata to version 3.5.1
+- Updated README version badges
+
 ---
 
 ## [v3.5.0] — 2025-05-22

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # O3 Deep Research - AI Marketing Automation System
 
-[![O3 Version](https://img.shields.io/badge/version-3.5.0-blue)](CHANGELOG.md)
+[![O3 Version](https://img.shields.io/badge/version-3.5.1-blue)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![CI/CD](https://github.com/DanCanadian/ADK/actions/workflows/validate_repo.yml/badge.svg)](https://github.com/DanCanadian/ADK/actions)
 
 This repository powers the O3 Deep Research initiative, an advanced AI-powered marketing automation system for ADV IT Performance Corp. It implements the V3.5 Unified Final prompt architecture with enhanced CI/CD validation, comprehensive research capabilities, and advanced agent coordination.
 
-## 🚀 Key Features (v3.5.0)
+## 🚀 Key Features (v3.5.1)
 
 - **Enhanced Multi-Agent System**: Specialized agents with clear responsibilities and improved coordination
 - **Advanced Prompt Patterns**: Implements ReAct, Chain-of-Thought, and Few-shot prompting
@@ -30,7 +30,7 @@ This repository powers the O3 Deep Research initiative, an advanced AI-powered m
 - [Release Checklist](docs/meta/release_checklist_v3.5.md) - Process for new releases
 - [Changelog](CHANGELOG.md) - Version history and changes
 
-## 📂 Repository Structure (V3.5.0)
+## 📂 Repository Structure (V3.5.1)
 
 ```
 .

--- a/docs/meta/legacy_map.md
+++ b/docs/meta/legacy_map.md
@@ -5,9 +5,16 @@ This document tracks the migration and deprecation of previous versions of the O
 ## Version History
 
 ### Current Version
+- **v3.5.1** (2025-05-23)
+  - Location: `docs/prompt/prompt_kernel_v3.5.md`
+  - Patch update adding simulation and evaluation sections
 - **v3.5.0** (2025-05-22)
   - Location: `docs/prompt/prompt_kernel_v3.5.md`
   - Key Features:
+    - Multi-agent coordination
+    - ReAct patterns implementation
+    - Enhanced CI/CD integration
+    - Comprehensive evaluation framework
     - Multi-agent coordination
     - ReAct patterns implementation
     - Enhanced CI/CD integration

--- a/docs/meta/meta_evaluation.json
+++ b/docs/meta/meta_evaluation.json
@@ -1,9 +1,9 @@
 {
   "version": "1.0.0",
-  "evaluation_date": "2025-05-22",
+  "evaluation_date": "2025-05-23",
   "evaluation_framework": {
     "name": "O3 Deep Research Evaluation Framework",
-    "version": "3.5.0"
+    "version": "3.5.1"
   },
   "evaluation_metrics": [
     {
@@ -104,9 +104,9 @@
   "version_history": [
     {
       "version": "1.0.0",
-      "date": "2025-05-22",
+      "date": "2025-05-23",
       "changes": [
-        "Initial version created for O3 Deep Research v3.5.0"
+        "Initial version created for O3 Deep Research v3.5.1"
       ]
     }
   ]

--- a/docs/meta/prompt_evolution_log/v3.5.yaml
+++ b/docs/meta/prompt_evolution_log/v3.5.yaml
@@ -1,5 +1,5 @@
-version: 3.5.0
-released: 2025-05-21
+version: 3.5.1
+released: 2025-05-23
 supersedes: 3.4.1
 repo: https://github.com/DanCanadian/ADK
 prompt_genome_id: pe-v3.5-repo-linked

--- a/docs/meta/prompt_genome.json
+++ b/docs/meta/prompt_genome.json
@@ -1,11 +1,11 @@
 {
   "prompt_genome": {
     "version": "1.2",
-    "last_updated": "2025-05-22",
+    "last_updated": "2025-05-23",
     "prompts": [
       {
-        "id": "o3-deep-research-v3.5",
-        "name": "O3 Deep Research V3.5 Unified Final",
+        "id": "o3-deep-research-v3.5.1",
+        "name": "O3 Deep Research V3.5.1",
         "description": "Advanced core prompt with multi-agent coordination, ReAct patterns, and enhanced CI validation",
         "created_at": "2025-05-22",
         "status": "active",

--- a/docs/prompt/prompt_kernel_v3.5.md
+++ b/docs/prompt/prompt_kernel_v3.5.md
@@ -579,6 +579,116 @@ output_format:
 - [Kaggle Prompt Engineering](https://www.kaggle.com/whitepaper-prompt-engineering)
 - [Google AI Studio](https://ai.google/studio)
 
+## 13. Simulation Block: 72-Hour PPC Lifecycle
+
+This block demonstrates a continuous three‑day cycle for validating real-world agent orchestration.
+
+| Day | Trigger | Agent | Action |
+|-----|---------|-------|--------|
+| **Day 1** | New budget + product drop | ResearchAgent | Market scan and brief generation |
+|           | Brief approved | ContentAgent | Produce landing pages and email drafts |
+|           | Creative approved | CampaignAgent | Launch campaigns across Google and Meta |
+|           | Performance dip detected | OptimizationAgent | Shift budget from weak ad groups |
+|           | Bounce spike on landing page | EngagementAgent | Trigger retargeting sequence |
+| **Day 2** | Morning analytics report shows low CTR | OptimizationAgent | Inject new ad copy variant |
+|           | Email engagement surges | CampaignAgent | Expand to LinkedIn and Instagram |
+|           | NSM drift > -2% | ConfigAgent | Mutate targeting schema |
+|           | Strategy audit | All agents | Sync memory state |
+| **Day 3** | Daily report requested | AnalyticsAgent | Summarize cross-channel impact |
+|           | Churn flag raised | ResearchAgent | Recommend new CTA framing |
+|           | Prompt drift detected | ConfigAgent | Retrain tone schema |
+|           | ROAS improves +4% | CampaignAgent | Scale winning variant regionally |
+
+All actions are logged in `logs/agents/{agent}.json` for traceability.
+
+## 14. Multi-Perspective Review
+
+**Architect Perspective**
+- Modular isolation of agents with clear interfaces.
+- Semantic cache enables long-term coherence.
+- *Watchpoint:* ensure fault tolerance for shared memory.
+
+**PromptOps Engineer Perspective**
+- Few-shot and CoT patterns improve reasoning.
+- Self-reflection logic embedded via `self_reflection.py`.
+- *Watchpoint:* tighten coupling between prompt refiners and mutators.
+
+**Product Strategist Perspective**
+- Each agent maps directly to a business KPI.
+- NSM applied across layers for goal consistency.
+- *Watchpoint:* human oversight for escalation scenarios.
+
+**Risk & Compliance Analyst Perspective**
+- Logging of all agent messages enables audits.
+- Drift detection handled via ConfigAgent.
+- *Watchpoint:* bias in training examples and GDPR compliance.
+
+## 15. Roadmap Milestones
+
+### Phase 1: Minimum Viable Agent System (0–3 months)
+- Implement ResearchAgent, ContentAgent, CampaignAgent.
+- Establish shared prompt formats and token budgets.
+- Run first campaign test via Google AI Studio.
+
+### Phase 2: Multi-Agent Orchestration & Learning (3–6 months)
+- Add EngagementAgent, OptimizationAgent, AnalyticsAgent.
+- Introduce semantic cache and messaging bus.
+- Connect NSM observability model.
+
+### Phase 3: Self-Tuning & Adaptive Scaling (6–12 months)
+- Add ConfigAgent with schema‑tuning logic.
+- Deploy self‑reflective evaluation pipelines.
+- Support multilingual prompting and LLM fallback.
+
+## 16. Prompt Genome Metadata
+
+```json
+{
+  "version": "v3.5.1",
+  "prompt_layers": [
+    {"id": "core-cof-ppc-001", "agent": "ResearchAgent", "pattern": "chain-of-thought"},
+    {"id": "creative-tone-v2", "agent": "ContentAgent", "pattern": "few-shot"},
+    {"id": "campaign-reflective-logic", "agent": "CampaignAgent", "pattern": "loop-planner"},
+    {"id": "retention-motivate-1a", "agent": "EngagementAgent", "pattern": "motivational adaptive"},
+    {"id": "optimization-tuner-auto", "agent": "OptimizationAgent", "pattern": "self-calibrating"}
+  ],
+  "last_update": "2025-05-23",
+  "registry_id": "O3_prompt_kernel_3.5.1"
+}
+```
+
+## 17. Meta-Evaluation Output
+
+```json
+{
+  "prompt_kernel_version": "v3.5.1",
+  "coverage_score": 0.96,
+  "coherence_rating": 0.93,
+  "prompt_patterns_utilized": ["few-shot", "chain-of-thought", "semantic caching", "ReAct", "self-reflection"],
+  "detected_weaknesses": ["needs better retry logic", "limited ConfigAgent testing"],
+  "review_timestamp": "2025-05-23T00:00:00Z",
+  "review_agent_id": "o3-eval-checker-v1"
+}
+```
+
+## 18. Prompt Evolution Hook
+
+Store evolution notes in `/meta/prompt_evolution_log/v3.5.yaml` using the format:
+
+```yaml
+version: 3.5.1
+reviewed_on: 2025-05-23
+kernel_strengths:
+  - Modular role-per-agent mapping
+  - Prompt genome with self-reflection
+areas_to_evolve:
+  - Add inter-agent governance layer
+  - Automate prompt mutation recovery
+next_kernel_notes:
+  - Explore GPT-5 compatibility
+  - Test token sharding across clusters
+```
+
 ## 🏁 Conclusion
 
 This document serves as the comprehensive blueprint for the O3 Deep Research multi-agent marketing system. By implementing this architecture, ADV IT Performance Corp will be positioned at the forefront of AI-powered marketing automation, with a system that learns, adapts, and optimizes continuously.

--- a/tests/golden_prompts/README.md
+++ b/tests/golden_prompts/README.md
@@ -33,8 +33,8 @@ markdownlint-cli2 "tests/golden_prompts/*.md"
 
 ## Versioning
 
-- **Current Version**: 3.5.0
-- **Compatibility**: O3 Prompt Kernel v3.5.0+
+- **Current Version**: 3.5.1
+- **Compatibility**: O3 Prompt Kernel v3.5.1+
 - **Last Updated**: 2025-05-22
 
 ## Contributing

--- a/tests/golden_prompts/test_kpi_optimization.md
+++ b/tests/golden_prompts/test_kpi_optimization.md
@@ -1,12 +1,13 @@
 ### 💬 INPUT
-Suggest a content strategy to maximize click-through rate (CTR) for a B2B SaaS product, considering user funnel stages.
+You are a marketing strategist agent. Your goal is to maximize ROI for a B2B campaign with a fixed $10K budget.
 
 ### ✅ EXPECTED
-- Segments user journey (TOFU / MOFU / BOFU)
-- Matches content type to stage (e.g., webinar for MOFU)
-- Optimizes CTA phrasing based on CTR patterns
-- Shows alignment with `Prompt Kernel v3.5` architecture map
+- Agent selects paid channel mix (e.g., Google Ads, LinkedIn)
+- Predicts CAC and LTV for each channel
+- Chooses mix with highest ROMI
+- Logs decision tree and justification
 
 ### 🔁 NOTES
-Prompt Kernel: v3.5  
+Tests business-alignment logic and metric tracing.
+
 **Tags:** KPI optimization, content strategy, content targeting

--- a/tests/golden_prompts/test_memory_reflection.md
+++ b/tests/golden_prompts/test_memory_reflection.md
@@ -1,12 +1,13 @@
 ### 💬 INPUT
-What insights can be retrieved from past performance data to improve this quarter's PPC planning?
+Simulate how an agent reflects on its prior actions after receiving contradictory feedback from a user.
 
 ### ✅ EXPECTED
-- MemoryAgent fetches campaign summary or KPI trends
-- Mentions meta-reflection mechanism (e.g., `BEGIN_REFLECTION`)
-- Suggests a change in targeting or budget allocation
-- Cites "ROI loop" or historical learning data
+- Agent retrieves memory trace of last response
+- Performs self_reflection.py to diagnose error
+- Regenerates improved message and annotates trace
+- Adds failed+corrected pair to memory database
 
 ### 🔁 NOTES
-Prompt Kernel: v3.5
+This tests long-term coherence and embedded self-diagnostics.
+
 **Tags:** memory retrieval, meta-reflection loop, performance learning

--- a/tests/golden_prompts/test_prompt_coordinator.md
+++ b/tests/golden_prompts/test_prompt_coordinator.md
@@ -1,13 +1,13 @@
 ### 💬 INPUT
-Act as a research agent coordinating with campaign and memory agents to optimize a digital ad strategy. Include ReAct-style reasoning and trigger a feedback loop.
+A customer has asked multiple agents to coordinate a product launch campaign. Simulate the cross-agent interaction including research, generation, and feedback loop.
 
 ### ✅ EXPECTED
-- Uses ReAct-style prompt chaining (`THOUGHT → ACTION → OBSERVATION`)
-- Shows message from MemoryAgent to refine parameters
-- Campaign strategy includes channel choice + timing
-- Ends with meta-reflection and optimization loop
+- ResearchAgent activates to gather market data
+- PromptGenerator creates launch messages
+- FeedbackLoop evaluates and refines output
+- All messages are archived in campaign_log.json
 
 ### 🔁 NOTES
-Prompt Kernel: v3.5
+Coordination follows ReAct loop, with explicit agent handoffs and reflection checkpoints.
 
 **Tags:** multi-agent coordination, ReAct


### PR DESCRIPTION
## Summary
- synchronize golden prompt tests with final specification
- update golden prompt README for version 3.5.1

## Testing
- `markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'` *(fails: MD022, MD013, etc.)*
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `yamllint docs/meta/prompt_evolution_log/v3.5.yaml` *(warns about missing document start)*