### PR TITLE
Add ChatGPT research workflow and bump docs to v3.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project are documented in this file.
 
+## [v3.5.3] — 2025-05-24
+
+### ✨ Updates
+- Added ChatGPT research workflow quickstart
+- Incremented documentation version to 3.5.3
+
+---
+
+## [v3.5.2] — 2025-05-24
+
+### ✨ Updates
+- Added GitHub integration guide for ChatGPT
+- Incremented documentation to version 3.5.2
+
+---
+
 ## [v3.5.1] — 2025-05-23
 
 ### ✨ Enhancements

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # O3 Deep Research - AI Marketing Automation System
 
-[![O3 Version](https://img.shields.io/badge/version-3.5.1-blue)](CHANGELOG.md)
+[![O3 Version](https://img.shields.io/badge/version-3.5.3-blue)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![CI/CD](https://github.com/DanCanadian/ADK/actions/workflows/validate_repo.yml/badge.svg)](https://github.com/DanCanadian/ADK/actions)
 
 This repository powers the O3 Deep Research initiative, an advanced AI-powered marketing automation system for ADV IT Performance Corp. It implements the V3.5 Unified Final prompt architecture with enhanced CI/CD validation, comprehensive research capabilities, and advanced agent coordination.
 
-## 🚀 Key Features (v3.5.1)
+## 🚀 Key Features (v3.5.3)
 
 - **Enhanced Multi-Agent System**: Specialized agents with clear responsibilities and improved coordination
 - **Advanced Prompt Patterns**: Implements ReAct, Chain-of-Thought, and Few-shot prompting
@@ -20,6 +20,8 @@ This repository powers the O3 Deep Research initiative, an advanced AI-powered m
 - [Prompt Kernel v3.5](docs/prompt/prompt_kernel_v3.5.md) - Core prompt engineering framework (latest)
 - [Prompt Evolution Log](docs/meta/prompt_evolution_log/v3.5.yaml) - Version history and changes
 - [Meta Evaluation](docs/meta/meta_evaluation.json) - Evaluation framework and metrics
+- [GitHub Integration Guide](docs/github_chatgpt_integration.md) - Connect this repository to ChatGPT
+- [ChatGPT Research Workflow](docs/chatgpt_research_workflow.md) - Quickstart for using this repo with ChatGPT
 
 ### Research & Methodology
 - [Research Goals](docs/RESEARCH_GOALS.md) - Overview of research objectives and success metrics
@@ -30,7 +32,7 @@ This repository powers the O3 Deep Research initiative, an advanced AI-powered m
 - [Release Checklist](docs/meta/release_checklist_v3.5.md) - Process for new releases
 - [Changelog](CHANGELOG.md) - Version history and changes
 
-## 📂 Repository Structure (V3.5.1)
+## 📂 Repository Structure (V3.5.3)
 
 ```
 .

--- a/docs/chatgpt_research_workflow.md
+++ b/docs/chatgpt_research_workflow.md
@@ -1,0 +1,24 @@
+# ChatGPT Research Workflow
+
+This quickstart explains how to leverage ChatGPT with the O3 Deep Research repository.
+
+## 1. Connect the Repository
+Follow the [GitHub Integration Guide](github_chatgpt_integration.md) to link the `ADK` repository to ChatGPT.
+
+## 2. Ask Research Questions
+Once connected, you can reference repository files directly in your prompts. Example:
+
+```
+Refer to the prompt kernel in docs/prompt/prompt_kernel_v3.5.md and summarize the agent roles.
+```
+
+## 3. Validate Locally
+Before pushing updates, run the repository checks:
+
+```bash
+markdownlint-cli2 "**/*.md" "#node_modules"
+yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}' .
+jq . docs/source_index.json
+```
+
+These commands ensure documentation and metadata remain consistent.

--- a/docs/github_chatgpt_integration.md
+++ b/docs/github_chatgpt_integration.md
@@ -1,0 +1,15 @@
+# Connecting GitHub to ChatGPT Deep Research
+
+This short guide explains how to link a GitHub repository to ChatGPT so that the O3 Deep Research agent can use it as an external knowledge source.
+
+## Steps
+1. Open ChatGPT and select **Connect GitHub Repository**.
+2. Authorize access to your GitHub account and choose the repository `ADK`.
+3. Once connected, ChatGPT can read files and reference them during conversations.
+
+For more details, see the official article: <https://help.openai.com/en/articles/11145903-connecting-github-to-chatgpt-deep-research>
+
+## Tips
+- Keep the repository public or grant appropriate access.
+- Update the repository regularly so ChatGPT uses the latest files.
+- Use file path references in your prompts for precise citations.

--- a/docs/meta/meta_evaluation.json
+++ b/docs/meta/meta_evaluation.json
@@ -3,7 +3,7 @@
   "evaluation_date": "2025-05-23",
   "evaluation_framework": {
     "name": "O3 Deep Research Evaluation Framework",
-    "version": "3.5.1"
+    "version": "3.5.3"
   },
   "evaluation_metrics": [
     {

--- a/docs/meta/prompt_evolution_log/v3.5.yaml
+++ b/docs/meta/prompt_evolution_log/v3.5.yaml
@@ -1,6 +1,6 @@
 ---
-version: 3.5.1
-released: 2025-05-23
+version: 3.5.3
+released: 2025-05-24
 supersedes: 3.4.1
 repo: https://github.com/DanCanadian/ADK
 prompt_genome_id: pe-v3.5-repo-linked
@@ -12,6 +12,10 @@ features:
   - Modular agent coordination
   - CI-ready prompt kernel
   - Chain-of-thought + ReAct
+  - GitHub integration guide
+  - ChatGPT research workflow
+notes:
+  - Version bump to 3.5.3
 origin:
   - file: prompt_kernel_v3.4.md
   - commits: [4a46185, 30d24e0, 004dc91]

--- a/docs/meta/prompt_genome.json
+++ b/docs/meta/prompt_genome.json
@@ -1,11 +1,11 @@
 {
   "prompt_genome": {
     "version": "1.2",
-    "last_updated": "2025-05-23",
+    "last_updated": "2025-05-24",
     "prompts": [
       {
-        "id": "o3-deep-research-v3.5.1",
-        "name": "O3 Deep Research V3.5.1",
+        "id": "o3-deep-research-v3.5.3",
+        "name": "O3 Deep Research V3.5.3",
         "description": "Advanced core prompt with multi-agent coordination, ReAct patterns, and enhanced CI validation",
         "created_at": "2025-05-22",
         "status": "active",

--- a/docs/prompt/prompt_kernel_v3.5.md
+++ b/docs/prompt/prompt_kernel_v3.5.md
@@ -645,7 +645,7 @@ All actions are logged in `logs/agents/{agent}.json` for traceability.
 
 ```json
 {
-  "version": "v3.5.1",
+  "version": "v3.5.3",
   "prompt_layers": [
     {"id": "core-cof-ppc-001", "agent": "ResearchAgent", "pattern": "chain-of-thought"},
     {"id": "creative-tone-v2", "agent": "ContentAgent", "pattern": "few-shot"},
@@ -654,7 +654,7 @@ All actions are logged in `logs/agents/{agent}.json` for traceability.
     {"id": "optimization-tuner-auto", "agent": "OptimizationAgent", "pattern": "self-calibrating"}
   ],
   "last_update": "2025-05-23",
-  "registry_id": "O3_prompt_kernel_3.5.1"
+  "registry_id": "O3_prompt_kernel_3.5.3"
 }
 ```
 
@@ -662,7 +662,7 @@ All actions are logged in `logs/agents/{agent}.json` for traceability.
 
 ```json
 {
-  "prompt_kernel_version": "v3.5.1",
+  "prompt_kernel_version": "v3.5.3",
   "coverage_score": 0.96,
   "coherence_rating": 0.93,
   "prompt_patterns_utilized": ["few-shot", "chain-of-thought", "semantic caching", "ReAct", "self-reflection"],
@@ -677,7 +677,7 @@ All actions are logged in `logs/agents/{agent}.json` for traceability.
 Store evolution notes in `/meta/prompt_evolution_log/v3.5.yaml` using the format:
 
 ```yaml
-version: 3.5.1
+version: 3.5.3
 reviewed_on: 2025-05-23
 kernel_strengths:
   - Modular role-per-agent mapping

--- a/docs/source_index.json
+++ b/docs/source_index.json
@@ -1,150 +1,290 @@
 {
   "sources": [
     {
-      "name": "O3 Deep Research v3.5.1",
+      "name": "O3 Deep Research v3.5.3",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/prompt/prompt_kernel_v3.5.md",
-      "tags": ["o3", "prompt-kernel", "v3.5.1", "research", "latest"],
-      "version": "3.5.1",
+      "tags": [
+        "o3",
+        "prompt-kernel",
+        "v3.5.3",
+        "research",
+        "latest"
+      ],
+      "version": "3.5.3",
       "type": "core"
     },
     {
       "name": "Prompt Evolution v3.5",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/meta/prompt_evolution_log/v3.5.yaml",
-      "tags": ["prompt-evolution", "v3.5.1", "meta"],
-      "version": "3.5.1",
+      "tags": [
+        "prompt-evolution",
+        "v3.5.3",
+        "meta"
+      ],
+      "version": "3.5.3",
       "type": "meta"
     },
     {
       "name": "Meta Evaluation Framework",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/meta/meta_evaluation.json",
-      "tags": ["evaluation", "framework", "v3.5.1"],
-      "version": "3.5.1",
+      "tags": [
+        "evaluation",
+        "framework",
+        "v3.5.3"
+      ],
+      "version": "3.5.3",
       "type": "evaluation"
     },
     {
       "name": "Version Diff v3.4.1 to v3.5.0",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/meta/version_diff_v3.4.1_to_v3.5.0.md",
-      "tags": ["migration", "v3.5.0", "changelog"],
+      "tags": [
+        "migration",
+        "v3.5.0",
+        "changelog"
+      ],
       "version": "3.5.0",
       "type": "documentation"
     },
     {
       "name": "Legacy Version Map",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/meta/legacy_map.md",
-      "tags": ["legacy", "versioning", "migration"],
-      "version": "3.5.1",
+      "tags": [
+        "legacy",
+        "versioning",
+        "migration"
+      ],
+      "version": "3.5.3",
       "type": "documentation"
     },
     {
       "name": "ADK Quickstart",
       "link": "https://cloud.google.com/vertex-ai/generative-ai/docs/agent-development-kit/quickstart",
-      "tags": ["adk", "google", "agents"],
+      "tags": [
+        "adk",
+        "google",
+        "agents"
+      ],
       "version": "1.0.0"
     },
     {
       "name": "Google ADK Docs",
       "link": "https://google.github.io/adk-docs/",
-      "tags": ["adk", "architecture", "modules"],
+      "tags": [
+        "adk",
+        "architecture",
+        "modules"
+      ],
       "version": "1.0.0"
     },
     {
       "name": "Kaggle Prompt Engineering",
       "link": "https://www.kaggle.com/whitepaper-prompt-engineering",
-      "tags": ["prompting", "few-shot", "react", "cot"],
+      "tags": [
+        "prompting",
+        "few-shot",
+        "react",
+        "cot"
+      ],
       "version": "1.0.0"
     },
     {
       "name": "IBM AI Learning",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/ibm_ai_learning.md",
-      "tags": ["ibm", "governance", "trust", "ai-ethics"],
+      "tags": [
+        "ibm",
+        "governance",
+        "trust",
+        "ai-ethics"
+      ],
       "version": "1.0.0"
     },
     {
       "name": "Google Gemini API",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/gemini_api_docs.md",
-      "tags": ["google", "gemini", "cloud-ai", "multimodal"],
+      "tags": [
+        "google",
+        "gemini",
+        "cloud-ai",
+        "multimodal"
+      ],
       "version": "1.0.0"
     },
     {
       "name": "OpenAI API Reference",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/openai_api_docs.md",
-      "tags": ["openai", "function-calling", "rag"],
+      "tags": [
+        "openai",
+        "function-calling",
+        "rag"
+      ],
       "version": "1.0.0"
     },
     {
       "name": "Microsoft AI Builder",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/microsoft_ai_builder.md",
-      "tags": ["microsoft", "power-platform", "automation"]
+      "tags": [
+        "microsoft",
+        "power-platform",
+        "automation"
+      ]
     },
     {
       "name": "NVIDIA Optimizations",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/nvidia_optimizations.md",
-      "tags": ["nvidia", "gpu", "inference", "tensorrt"]
+      "tags": [
+        "nvidia",
+        "gpu",
+        "inference",
+        "tensorrt"
+      ]
     },
     {
       "name": "AMD Developer AI",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/amd_developer_ai.md",
-      "tags": ["amd", "rocm", "ai-acceleration"]
+      "tags": [
+        "amd",
+        "rocm",
+        "ai-acceleration"
+      ]
     },
     {
       "name": "Vertex AI Platform",
       "link": "https://cloud.google.com/vertex-ai/docs/start/introduction-unified-platform",
-      "tags": ["google", "vertex-ai", "ml-platform", "deployment"]
+      "tags": [
+        "google",
+        "vertex-ai",
+        "ml-platform",
+        "deployment"
+      ]
     },
     {
       "name": "Gemini on Google Cloud",
       "link": "https://cloud.google.com/gemini/docs",
-      "tags": ["google", "gemini", "cloud", "ai"]
+      "tags": [
+        "google",
+        "gemini",
+        "cloud",
+        "ai"
+      ]
     },
     {
       "name": "OpenAI Platform Docs",
       "link": "https://platform.openai.com/docs/overview",
-      "tags": ["openai", "llm", "tools", "api"]
+      "tags": [
+        "openai",
+        "llm",
+        "tools",
+        "api"
+      ]
     },
     {
       "name": "IBM Developer – AI Technology",
       "link": "https://developer.ibm.com/technologies/artificial-intelligence/",
-      "tags": ["ibm", "ai", "sdk", "enterprise"]
+      "tags": [
+        "ibm",
+        "ai",
+        "sdk",
+        "enterprise"
+      ]
     },
     {
       "name": "Microsoft AI Builder",
       "link": "https://learn.microsoft.com/en-us/ai-builder/",
-      "tags": ["microsoft", "ai-builder", "enterprise", "automation"]
+      "tags": [
+        "microsoft",
+        "ai-builder",
+        "enterprise",
+        "automation"
+      ]
     },
     {
       "name": "NVIDIA Developer Docs",
       "link": "https://docs.nvidia.com/",
-      "tags": ["nvidia", "gpu", "ai-hardware", "performance"]
+      "tags": [
+        "nvidia",
+        "gpu",
+        "ai-hardware",
+        "performance"
+      ]
     },
     {
       "name": "AMD AI Developer Hub",
       "link": "https://www.amd.com/en/developer.html",
-      "tags": ["amd", "ai", "hardware", "development"]
+      "tags": [
+        "amd",
+        "ai",
+        "hardware",
+        "development"
+      ]
     },
     {
       "name": "McKinsey AI in Marketing",
       "link": "https://www.mckinsey.com/capabilities/growth-marketing-and-sales/our-insights/a-360-degree-look-at-ai-in-marketing-sales-and-customer-service",
-      "tags": ["mckinsey", "ai", "strategy", "marketing"]
+      "tags": [
+        "mckinsey",
+        "ai",
+        "strategy",
+        "marketing"
+      ]
     },
     {
       "name": "NeuroGym by John Assaraf",
       "link": "https://www.myneurogym.com/",
-      "tags": ["neuromarketing", "attention", "motivation", "assaraf"]
+      "tags": [
+        "neuromarketing",
+        "attention",
+        "motivation",
+        "assaraf"
+      ]
     },
     {
       "name": "Reforge Growth Systems",
       "link": "https://www.reforge.com/",
-      "tags": ["growth", "loop", "retention", "balfour", "experimentation"]
+      "tags": [
+        "growth",
+        "loop",
+        "retention",
+        "balfour",
+        "experimentation"
+      ]
     },
     {
       "name": "O3 Release Checklist",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/meta/release_checklist_v3.5.md",
-      "tags": ["o3", "release", "checklist", "process"]
+      "tags": [
+        "o3",
+        "release",
+        "checklist",
+        "process"
+      ]
+    },
+    {
+      "name": "GitHub Integration Guide",
+      "link": "https://github.com/DanCanadian/ADK/blob/main/docs/github_chatgpt_integration.md",
+      "tags": [
+        "chatgpt",
+        "github",
+        "integration"
+      ],
+      "version": "3.5.3",
+      "type": "documentation"
+    },
+    {
+      "name": "ChatGPT Research Workflow",
+      "link": "https://github.com/DanCanadian/ADK/blob/main/docs/chatgpt_research_workflow.md",
+      "tags": [
+        "chatgpt",
+        "workflow",
+        "quickstart"
+      ],
+      "version": "3.5.3",
+      "type": "documentation"
     }
   ],
   "metadata": {
     "include_web": true,
-    "last_updated": "2025-05-23",
-    "version": "3.5.1"
+    "last_updated": "2025-05-24",
+    "version": "3.5.3"
   }
 }


### PR DESCRIPTION
## Summary
- document how to use the repo with ChatGPT in `chatgpt_research_workflow.md`
- reference the workflow from the README
- update CHANGELOG with a v3.5.3 entry
- bump docs and metadata to version 3.5.3 and register the new doc in `source_index.json`

## Testing
- `npx markdownlint-cli2 "**/*.md" "#node_modules"` *(fails: MD024 in CHANGELOG and other pre‑existing issues)*
- `yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}' .`
- `jq . docs/source_index.json`
