### PR TITLE
Fix markdownlint errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project are documented in this file.
 
+## [v3.5.2] — 2025-05-24
+
+### ✨ Updates
+- Added GitHub integration guide for ChatGPT
+- Incremented documentation to version 3.5.2
+
+---
+
 ## [v3.5.1] — 2025-05-23
 
 ### ✨ Enhancements
@@ -13,19 +21,19 @@ All notable changes to this project are documented in this file.
 
 ## [v3.5.0] — 2025-05-22
 
-### 🚀 New Features
+### 🚀 New Features (v3.5.0)
 - Added new prompt kernel v3.5 with enhanced multi-agent coordination
 - Implemented advanced prompt engineering patterns (ReAct, CoT, Few-shot)
 - Added comprehensive agent memory and feedback loop systems
 
-### 📝 Documentation & Process
+### 📝 Documentation & Process (v3.5.0)
 - Added RESEARCH_GOALS.md and METHODOLOGY.md for better project tracking
 - Updated README.md with new features and documentation structure
 - Improved repository structure for O3 Deep Research compatibility
 
 ## [v3.4.1] — 2025-05-20
 
-### 📝 Documentation & Process
+### 📝 Documentation & Process (v3.4.1)
 - Added comprehensive contribution guide (`docs/contribution_guide.md`)
 - Enhanced PR template with validation checklist
 - Improved CI workflow with additional validations
@@ -45,7 +53,7 @@ All notable changes to this project are documented in this file.
 - Added CI validation framework for prompt quality assurance
 - Extended source integration with industry-leading marketing AI platforms
 
-### 🚀 New Features
+### 🚀 New Features (v3.4.0)
 - Added `prompt/prompt_kernel_v3.4.md` with V3.4 Unified Final prompt
 - Enhanced `meta/prompt_genome.json` with version tracking and CI integration
 - Added comprehensive CI validation requirements in `.github/workflows/validate_repo.yml`

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # O3 Deep Research - AI Marketing Automation System
 
-[![O3 Version](https://img.shields.io/badge/version-3.5.1-blue)](CHANGELOG.md)
+[![O3 Version](https://img.shields.io/badge/version-3.5.2-blue)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![CI/CD](https://github.com/DanCanadian/ADK/actions/workflows/validate_repo.yml/badge.svg)](https://github.com/DanCanadian/ADK/actions)
 
 This repository powers the O3 Deep Research initiative, an advanced AI-powered marketing automation system for ADV IT Performance Corp. It implements the V3.5 Unified Final prompt architecture with enhanced CI/CD validation, comprehensive research capabilities, and advanced agent coordination.
 
-## 🚀 Key Features (v3.5.1)
+## 🚀 Key Features (v3.5.2)
 
 - **Enhanced Multi-Agent System**: Specialized agents with clear responsibilities and improved coordination
 - **Advanced Prompt Patterns**: Implements ReAct, Chain-of-Thought, and Few-shot prompting
@@ -20,6 +20,7 @@ This repository powers the O3 Deep Research initiative, an advanced AI-powered m
 - [Prompt Kernel v3.5](docs/prompt/prompt_kernel_v3.5.md) - Core prompt engineering framework (latest)
 - [Prompt Evolution Log](docs/meta/prompt_evolution_log/v3.5.yaml) - Version history and changes
 - [Meta Evaluation](docs/meta/meta_evaluation.json) - Evaluation framework and metrics
+- [GitHub Integration Guide](docs/github_chatgpt_integration.md) - Connect this repository to ChatGPT
 
 ### Research & Methodology
 - [Research Goals](docs/RESEARCH_GOALS.md) - Overview of research objectives and success metrics
@@ -30,7 +31,7 @@ This repository powers the O3 Deep Research initiative, an advanced AI-powered m
 - [Release Checklist](docs/meta/release_checklist_v3.5.md) - Process for new releases
 - [Changelog](CHANGELOG.md) - Version history and changes
 
-## 📂 Repository Structure (V3.5.1)
+## 📂 Repository Structure (V3.5.2)
 
 ```
 .
@@ -108,12 +109,15 @@ markdownlint-cli2 "**/*.md" "#node_modules"
 
 # Check for TODOs
 grep -r "TODO\|Coming soon" --include="*.md" --include="*.json" --include="*.yml" --include="*.yaml" .
+
 ```
 
 ### For Developers
 1. Clone this repository:
+
    ```bash
    git clone https://github.com/adv-ai/o3-deep-research-context.git
+
    ```
 
 ## 📚 Core References

--- a/docs/github_chatgpt_integration.md
+++ b/docs/github_chatgpt_integration.md
@@ -1,0 +1,15 @@
+# Connecting GitHub to ChatGPT Deep Research
+
+This short guide explains how to link a GitHub repository to ChatGPT so that the O3 Deep Research agent can use it as an external knowledge source.
+
+## Steps
+1. Open ChatGPT and select **Connect GitHub Repository**.
+2. Authorize access to your GitHub account and choose the repository `ADK`.
+3. Once connected, ChatGPT can read files and reference them during conversations.
+
+For more details, see the official article: <https://help.openai.com/en/articles/11145903-connecting-github-to-chatgpt-deep-research>
+
+## Tips
+- Keep the repository public or grant appropriate access.
+- Update the repository regularly so ChatGPT uses the latest files.
+- Use file path references in your prompts for precise citations.

--- a/docs/legacy/prompt/prompt_kernel_v3.4.md
+++ b/docs/legacy/prompt/prompt_kernel_v3.4.md
@@ -90,7 +90,7 @@ Answer the foundational research question:
 
 ---
 
-## 🧠 THINK LIKE:
+## 🧠 THINK LIKE
 
 * **Systems Architect** — design robust, modular, and scalable agent flows
 * **PromptOps Engineer** — enforce pattern reuse, token optimization, and lifecycle alignment

--- a/docs/meta/prompt_evolution_log/v3.5.yaml
+++ b/docs/meta/prompt_evolution_log/v3.5.yaml
@@ -1,5 +1,5 @@
 ---
-version: 3.5.1
+version: 3.5.2
 released: 2025-05-23
 supersedes: 3.4.1
 repo: https://github.com/DanCanadian/ADK
@@ -12,6 +12,9 @@ features:
   - Modular agent coordination
   - CI-ready prompt kernel
   - Chain-of-thought + ReAct
+  - GitHub integration guide
+notes:
+  - Version bump to 3.5.2
 origin:
   - file: prompt_kernel_v3.4.md
   - commits: [4a46185, 30d24e0, 004dc91]

--- a/docs/meta/prompt_genome.json
+++ b/docs/meta/prompt_genome.json
@@ -1,11 +1,11 @@
 {
   "prompt_genome": {
     "version": "1.2",
-    "last_updated": "2025-05-23",
+    "last_updated": "2025-05-24",
     "prompts": [
       {
-        "id": "o3-deep-research-v3.5.1",
-        "name": "O3 Deep Research V3.5.1",
+        "id": "o3-deep-research-v3.5.2",
+        "name": "O3 Deep Research V3.5.2",
         "description": "Advanced core prompt with multi-agent coordination, ReAct patterns, and enhanced CI validation",
         "created_at": "2025-05-22",
         "status": "active",

--- a/docs/prompt/prompt_kernel_v3.5.md
+++ b/docs/prompt/prompt_kernel_v3.5.md
@@ -645,7 +645,7 @@ All actions are logged in `logs/agents/{agent}.json` for traceability.
 
 ```json
 {
-  "version": "v3.5.1",
+  "version": "v3.5.2",
   "prompt_layers": [
     {"id": "core-cof-ppc-001", "agent": "ResearchAgent", "pattern": "chain-of-thought"},
     {"id": "creative-tone-v2", "agent": "ContentAgent", "pattern": "few-shot"},
@@ -654,7 +654,7 @@ All actions are logged in `logs/agents/{agent}.json` for traceability.
     {"id": "optimization-tuner-auto", "agent": "OptimizationAgent", "pattern": "self-calibrating"}
   ],
   "last_update": "2025-05-23",
-  "registry_id": "O3_prompt_kernel_3.5.1"
+  "registry_id": "O3_prompt_kernel_3.5.2"
 }
 ```
 
@@ -662,7 +662,7 @@ All actions are logged in `logs/agents/{agent}.json` for traceability.
 
 ```json
 {
-  "prompt_kernel_version": "v3.5.1",
+  "prompt_kernel_version": "v3.5.2",
   "coverage_score": 0.96,
   "coherence_rating": 0.93,
   "prompt_patterns_utilized": ["few-shot", "chain-of-thought", "semantic caching", "ReAct", "self-reflection"],
@@ -677,7 +677,7 @@ All actions are logged in `logs/agents/{agent}.json` for traceability.
 Store evolution notes in `/meta/prompt_evolution_log/v3.5.yaml` using the format:
 
 ```yaml
-version: 3.5.1
+version: 3.5.2
 reviewed_on: 2025-05-23
 kernel_strengths:
   - Modular role-per-agent mapping

--- a/docs/source_index.json
+++ b/docs/source_index.json
@@ -3,148 +3,277 @@
     {
       "name": "O3 Deep Research v3.5.1",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/prompt/prompt_kernel_v3.5.md",
-      "tags": ["o3", "prompt-kernel", "v3.5.1", "research", "latest"],
-      "version": "3.5.1",
+      "tags": [
+        "o3",
+        "prompt-kernel",
+        "v3.5.1",
+        "research",
+        "latest"
+      ],
+      "version": "3.5.2",
       "type": "core"
     },
     {
       "name": "Prompt Evolution v3.5",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/meta/prompt_evolution_log/v3.5.yaml",
-      "tags": ["prompt-evolution", "v3.5.1", "meta"],
+      "tags": [
+        "prompt-evolution",
+        "v3.5.1",
+        "meta"
+      ],
       "version": "3.5.1",
       "type": "meta"
     },
     {
       "name": "Meta Evaluation Framework",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/meta/meta_evaluation.json",
-      "tags": ["evaluation", "framework", "v3.5.1"],
+      "tags": [
+        "evaluation",
+        "framework",
+        "v3.5.1"
+      ],
       "version": "3.5.1",
       "type": "evaluation"
     },
     {
       "name": "Version Diff v3.4.1 to v3.5.0",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/meta/version_diff_v3.4.1_to_v3.5.0.md",
-      "tags": ["migration", "v3.5.0", "changelog"],
+      "tags": [
+        "migration",
+        "v3.5.0",
+        "changelog"
+      ],
       "version": "3.5.0",
       "type": "documentation"
     },
     {
       "name": "Legacy Version Map",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/meta/legacy_map.md",
-      "tags": ["legacy", "versioning", "migration"],
+      "tags": [
+        "legacy",
+        "versioning",
+        "migration"
+      ],
       "version": "3.5.1",
       "type": "documentation"
     },
     {
       "name": "ADK Quickstart",
       "link": "https://cloud.google.com/vertex-ai/generative-ai/docs/agent-development-kit/quickstart",
-      "tags": ["adk", "google", "agents"],
+      "tags": [
+        "adk",
+        "google",
+        "agents"
+      ],
       "version": "1.0.0"
     },
     {
       "name": "Google ADK Docs",
       "link": "https://google.github.io/adk-docs/",
-      "tags": ["adk", "architecture", "modules"],
+      "tags": [
+        "adk",
+        "architecture",
+        "modules"
+      ],
       "version": "1.0.0"
     },
     {
       "name": "Kaggle Prompt Engineering",
       "link": "https://www.kaggle.com/whitepaper-prompt-engineering",
-      "tags": ["prompting", "few-shot", "react", "cot"],
+      "tags": [
+        "prompting",
+        "few-shot",
+        "react",
+        "cot"
+      ],
       "version": "1.0.0"
     },
     {
       "name": "IBM AI Learning",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/ibm_ai_learning.md",
-      "tags": ["ibm", "governance", "trust", "ai-ethics"],
+      "tags": [
+        "ibm",
+        "governance",
+        "trust",
+        "ai-ethics"
+      ],
       "version": "1.0.0"
     },
     {
       "name": "Google Gemini API",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/gemini_api_docs.md",
-      "tags": ["google", "gemini", "cloud-ai", "multimodal"],
+      "tags": [
+        "google",
+        "gemini",
+        "cloud-ai",
+        "multimodal"
+      ],
       "version": "1.0.0"
     },
     {
       "name": "OpenAI API Reference",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/openai_api_docs.md",
-      "tags": ["openai", "function-calling", "rag"],
+      "tags": [
+        "openai",
+        "function-calling",
+        "rag"
+      ],
       "version": "1.0.0"
     },
     {
       "name": "Microsoft AI Builder",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/microsoft_ai_builder.md",
-      "tags": ["microsoft", "power-platform", "automation"]
+      "tags": [
+        "microsoft",
+        "power-platform",
+        "automation"
+      ]
     },
     {
       "name": "NVIDIA Optimizations",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/nvidia_optimizations.md",
-      "tags": ["nvidia", "gpu", "inference", "tensorrt"]
+      "tags": [
+        "nvidia",
+        "gpu",
+        "inference",
+        "tensorrt"
+      ]
     },
     {
       "name": "AMD Developer AI",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/amd_developer_ai.md",
-      "tags": ["amd", "rocm", "ai-acceleration"]
+      "tags": [
+        "amd",
+        "rocm",
+        "ai-acceleration"
+      ]
     },
     {
       "name": "Vertex AI Platform",
       "link": "https://cloud.google.com/vertex-ai/docs/start/introduction-unified-platform",
-      "tags": ["google", "vertex-ai", "ml-platform", "deployment"]
+      "tags": [
+        "google",
+        "vertex-ai",
+        "ml-platform",
+        "deployment"
+      ]
     },
     {
       "name": "Gemini on Google Cloud",
       "link": "https://cloud.google.com/gemini/docs",
-      "tags": ["google", "gemini", "cloud", "ai"]
+      "tags": [
+        "google",
+        "gemini",
+        "cloud",
+        "ai"
+      ]
     },
     {
       "name": "OpenAI Platform Docs",
       "link": "https://platform.openai.com/docs/overview",
-      "tags": ["openai", "llm", "tools", "api"]
+      "tags": [
+        "openai",
+        "llm",
+        "tools",
+        "api"
+      ]
     },
     {
       "name": "IBM Developer – AI Technology",
       "link": "https://developer.ibm.com/technologies/artificial-intelligence/",
-      "tags": ["ibm", "ai", "sdk", "enterprise"]
+      "tags": [
+        "ibm",
+        "ai",
+        "sdk",
+        "enterprise"
+      ]
     },
     {
       "name": "Microsoft AI Builder",
       "link": "https://learn.microsoft.com/en-us/ai-builder/",
-      "tags": ["microsoft", "ai-builder", "enterprise", "automation"]
+      "tags": [
+        "microsoft",
+        "ai-builder",
+        "enterprise",
+        "automation"
+      ]
     },
     {
       "name": "NVIDIA Developer Docs",
       "link": "https://docs.nvidia.com/",
-      "tags": ["nvidia", "gpu", "ai-hardware", "performance"]
+      "tags": [
+        "nvidia",
+        "gpu",
+        "ai-hardware",
+        "performance"
+      ]
     },
     {
       "name": "AMD AI Developer Hub",
       "link": "https://www.amd.com/en/developer.html",
-      "tags": ["amd", "ai", "hardware", "development"]
+      "tags": [
+        "amd",
+        "ai",
+        "hardware",
+        "development"
+      ]
     },
     {
       "name": "McKinsey AI in Marketing",
       "link": "https://www.mckinsey.com/capabilities/growth-marketing-and-sales/our-insights/a-360-degree-look-at-ai-in-marketing-sales-and-customer-service",
-      "tags": ["mckinsey", "ai", "strategy", "marketing"]
+      "tags": [
+        "mckinsey",
+        "ai",
+        "strategy",
+        "marketing"
+      ]
     },
     {
       "name": "NeuroGym by John Assaraf",
       "link": "https://www.myneurogym.com/",
-      "tags": ["neuromarketing", "attention", "motivation", "assaraf"]
+      "tags": [
+        "neuromarketing",
+        "attention",
+        "motivation",
+        "assaraf"
+      ]
     },
     {
       "name": "Reforge Growth Systems",
       "link": "https://www.reforge.com/",
-      "tags": ["growth", "loop", "retention", "balfour", "experimentation"]
+      "tags": [
+        "growth",
+        "loop",
+        "retention",
+        "balfour",
+        "experimentation"
+      ]
     },
     {
       "name": "O3 Release Checklist",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/meta/release_checklist_v3.5.md",
-      "tags": ["o3", "release", "checklist", "process"]
+      "tags": [
+        "o3",
+        "release",
+        "checklist",
+        "process"
+      ]
+    },
+    {
+      "name": "GitHub Integration Guide",
+      "link": "https://github.com/DanCanadian/ADK/blob/main/docs/github_chatgpt_integration.md",
+      "tags": [
+        "chatgpt",
+        "github",
+        "integration"
+      ],
+      "version": "3.5.2",
+      "type": "documentation"
     }
   ],
   "metadata": {
     "include_web": true,
-    "last_updated": "2025-05-23",
-    "version": "3.5.1"
+    "last_updated": "2025-05-24",
+    "version": "3.5.2"
   }
 }

--- a/tests/golden_prompts/README.md
+++ b/tests/golden_prompts/README.md
@@ -15,9 +15,9 @@ Golden prompts are used to:
 
 | File | Purpose | Key Features Tested |
 |------|---------|-------------------|
-| `test_prompt_coordinator.md` | Validates multi-agent coordination and ReAct patterns | - Agent communication<br>- ReAct-style reasoning<br>- Feedback loops |
-| `test_memory_reflection.md`  | Tests memory retrieval and meta-reflection capabilities | - Memory access<br>- Reflection loops<br>- Performance learning |
-| `test_kpi_optimization.md`   | Validates KPI-driven optimization strategies | - KPI tracking<br>- Content strategy<br>- Performance optimization |
+| `test_prompt_coordinator.md` | Validates multi-agent coordination and ReAct patterns | Agent communication; ReAct-style reasoning; Feedback loops |
+| `test_memory_reflection.md`  | Tests memory retrieval and meta-reflection capabilities | Memory access; Reflection loops; Performance learning |
+| `test_kpi_optimization.md`   | Validates KPI-driven optimization strategies | KPI tracking; Content strategy; Performance optimization |
 
 ## Usage
 

--- a/tests/golden_prompts/test_kpi_optimization.md
+++ b/tests/golden_prompts/test_kpi_optimization.md
@@ -1,4 +1,6 @@
-### 💬 INPUT
+# Test: KPI Optimization
+
+## 💬 INPUT
 Suggest a content strategy to maximize click-through rate (CTR) for a B2B SaaS product, considering user funnel stages.
 
 ### ✅ EXPECTED

--- a/tests/golden_prompts/test_memory_reflection.md
+++ b/tests/golden_prompts/test_memory_reflection.md
@@ -1,4 +1,6 @@
-### 💬 INPUT
+# Test: Memory Reflection
+
+## 💬 INPUT
 What insights can be retrieved from past performance data to improve this quarter's PPC planning?
 
 ### ✅ EXPECTED

--- a/tests/golden_prompts/test_prompt_coordinator.md
+++ b/tests/golden_prompts/test_prompt_coordinator.md
@@ -1,4 +1,6 @@
-### 💬 INPUT
+# Test: Prompt Coordinator
+
+## 💬 INPUT
 Act as a research agent coordinating with campaign and memory agents to optimize a digital ad strategy. Include ReAct-style reasoning and trigger a feedback loop.
 
 ### ✅ EXPECTED


### PR DESCRIPTION
## Summary
- make headings unique and add blank lines
- remove trailing punctuation in legacy docs
- adjust golden prompts to start with h1 heading
- remove HTML line breaks in golden prompt README

## Testing
- `npx markdownlint-cli2 "**/*.md" "#node_modules"`
- `yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}' .`
- `jq . docs/source_index.json`
