### PR TITLE
Cleanup tests and add sample agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 📓 CHANGELOG.md — O3 Deep Research Repository
+<!-- markdownlint-disable MD024 -->
 
 All notable changes to this project are documented in this file.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ This repository powers the O3 Deep Research initiative, an advanced AI-powered m
 - [Release Checklist](docs/meta/release_checklist_v3.5.md) - Process for new releases
 - [Changelog](CHANGELOG.md) - Version history and changes
 
-
 ## 📂 Repository Structure (v3.5.3)
 ├── .github/               # GitHub configuration and workflows
 │   └── workflows/
@@ -118,6 +117,7 @@ This repository includes GitHub Actions workflows that automatically validate:
 - CHANGELOG format
 
 To run validations locally:
+
 ```bash
 # Install dependencies (one time)
 ./scripts/setup_env.sh
@@ -131,6 +131,7 @@ grep -r "TODO\|Coming soon" --include="*.md" --include="*.json" --include="*.yml
 
 ### For Developers
 1. Clone this repository:
+
    ```bash
    git clone https://github.com/adv-ai/o3-deep-research-context.git
    ```

--- a/docs/legacy/prompt/prompt_kernel_v3.4.md
+++ b/docs/legacy/prompt/prompt_kernel_v3.4.md
@@ -90,7 +90,7 @@ Answer the foundational research question:
 
 ---
 
-## 🧠 THINK LIKE:
+## 🧠 THINK LIKE
 
 * **Systems Architect** — design robust, modular, and scalable agent flows
 * **PromptOps Engineer** — enforce pattern reuse, token optimization, and lifecycle alignment

--- a/src/README.md
+++ b/src/README.md
@@ -1,1 +1,7 @@
-# Source Code
+# Source Code Examples
+
+This directory contains minimal agent implementations used for testing and documentation purposes.
+
+- `sample_agent.py` – a toy example that echoes user input.
+
+Additional agents can be added here to demonstrate best practices for O3 Deep Research.

--- a/src/sample_agent.py
+++ b/src/sample_agent.py
@@ -1,0 +1,14 @@
+class EchoAgent:
+    """Simple agent that echoes received messages."""
+
+    def __init__(self, name: str = "EchoAgent") -> None:
+        self.name = name
+
+    def run(self, message: str) -> str:
+        """Return a formatted echo response."""
+        return f"{self.name}: {message}"
+
+
+if __name__ == "__main__":
+    agent = EchoAgent()
+    print(agent.run("Hello world"))

--- a/tests/golden_prompts/README.md
+++ b/tests/golden_prompts/README.md
@@ -15,9 +15,9 @@ Golden prompts are used to:
 
 | File | Purpose | Key Features Tested |
 |------|---------|-------------------|
-| `test_prompt_coordinator.md` | Validates multi-agent coordination and ReAct patterns | - Agent communication<br>- ReAct-style reasoning<br>- Feedback loops |
-| `test_memory_reflection.md`  | Tests memory retrieval and meta-reflection capabilities | - Memory access<br>- Reflection loops<br>- Performance learning |
-| `test_kpi_optimization.md`   | Validates KPI-driven optimization strategies | - KPI tracking<br>- Content strategy<br>- Performance optimization |
+| `test_prompt_coordinator.md` | Validates multi-agent coordination and ReAct patterns | Agent communication; ReAct-style reasoning; Feedback loops |
+| `test_memory_reflection.md`  | Tests memory retrieval and meta-reflection capabilities | Memory access; Reflection loops; Performance learning |
+| `test_kpi_optimization.md`   | Validates KPI-driven optimization strategies | KPI tracking; Content strategy; Performance optimization |
 
 ## Usage
 
@@ -48,28 +48,6 @@ When adding new golden prompts:
 3. Add relevant tags
 4. Update this README
 5. Ensure CI passes
-### -INPUT
-Example placeholder for CI validation.
-
-### -EXPECTED
-This README file passes section checks.
-
-### -NOTES
-Demonstration of required headers.
-
-**Tags:** example
-
-
-### -INPUT
-N/A
-
-### -EXPECTED
-N/A
-
-### -NOTES
-Prompt Kernel: v3.5
-**Tags:** documentation
-
 ## Related Documentation
 
 - [Prompt Kernel v3.5 Documentation](./../../docs/prompt/prompt_kernel_v3.5.md)
@@ -77,15 +55,11 @@ Prompt Kernel: v3.5
 - [CI Configuration](./../../.github/workflows/validate_repo.yml)
 
 ### INPUT
-
-Placeholder for validation.
+Explain the purpose of golden prompts.
 
 ### EXPECTED
-
-Placeholder for validation.
+- Overview of how golden prompts ensure stable behavior
 
 ### NOTES
-
-Placeholder for validation.
-
-**Tags:** placeholder
+Prompt Kernel: v3.5
+**Tags:** documentation

--- a/tests/golden_prompts/test_kpi_optimization.md
+++ b/tests/golden_prompts/test_kpi_optimization.md
@@ -1,12 +1,15 @@
-### -INPUT
+# KPI Optimization
+<!-- markdownlint-disable MD001 -->
+
+### INPUT
 Suggest a content strategy to maximize click-through rate (CTR) for a B2B SaaS product, considering user funnel stages.
 
-### -EXPECTED
+### EXPECTED
 - Segments user journey (TOFU / MOFU / BOFU)
 - Matches content type to stage (e.g., webinar for MOFU)
 - Optimizes CTA phrasing based on CTR patterns
 - Shows alignment with `Prompt Kernel v3.5` architecture map
 
-### -NOTES
+### NOTES
 Prompt Kernel: v3.5  
 **Tags:** KPI optimization, content strategy, content targeting

--- a/tests/golden_prompts/test_memory_reflection.md
+++ b/tests/golden_prompts/test_memory_reflection.md
@@ -1,12 +1,15 @@
-### -INPUT
+# Memory Reflection
+<!-- markdownlint-disable MD001 -->
+
+### INPUT
 What insights can be retrieved from past performance data to improve this quarter's PPC planning?
 
-### -EXPECTED
+### EXPECTED
 - MemoryAgent fetches campaign summary or KPI trends
 - Mentions meta-reflection mechanism (e.g., `BEGIN_REFLECTION`)
 - Suggests a change in targeting or budget allocation
 - Cites "ROI loop" or historical learning data
 
-### -NOTES
+### NOTES
 Prompt Kernel: v3.5
 **Tags:** memory retrieval, meta-reflection loop, performance learning

--- a/tests/golden_prompts/test_prompt_coordinator.md
+++ b/tests/golden_prompts/test_prompt_coordinator.md
@@ -1,14 +1,17 @@
-### -INPUT
+# Prompt Coordinator
+<!-- markdownlint-disable MD001 -->
+
+### INPUT
 Act as a research agent coordinating with campaign and memory agents to optimize a digital ad strategy. Include ReAct-style reasoning and trigger a feedback loop.
 
-### -EXPECTED
+### EXPECTED
 
 - Uses ReAct-style prompt chaining (`THOUGHT → ACTION → OBSERVATION`)
 - Shows message from MemoryAgent to refine parameters
 - Campaign strategy includes channel choice + timing
 - Ends with meta-reflection and optimization loop
 
-### -NOTES
+### NOTES
 Prompt Kernel: v3.5
 
 **Tags:** multi-agent coordination, ReAct


### PR DESCRIPTION
## Summary
- clean golden prompts and fix README placeholders
- adjust markdown headers and linter configuration
- include example agent in `src/`
- fix minor docs lint issues

## Testing
- `bash scripts/validate_golden_prompts.sh`
- `npx markdownlint-cli2 '**/*.md'`
- `python3 src/sample_agent.py`