### PR TITLE
Improve golden prompt validation and add agent stubs

### DIFF
--- a/.github/workflows/validate_repo.yml
+++ b/.github/workflows/validate_repo.yml
@@ -97,11 +97,12 @@ jobs:
         run: |
           echo "Validating golden prompts..."
           for file in tests/golden_prompts/*.md; do
+            [ "$(basename "$file")" = "README.md" ] && continue
             echo "🔍 Validating $file"
 
             # Check required sections
             for section in "INPUT" "EXPECTED" "NOTES"; do
-              if ! grep -q "^### .$section" "$file"; then
+              if ! grep -q "^### $section" "$file"; then
                 echo "❌ Missing section: $section in $file"
                 exit 1
               fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 📓 CHANGELOG.md — O3 Deep Research Repository
+<!-- markdownlint-disable MD024 -->
 
 All notable changes to this project are documented in this file.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ This repository powers the O3 Deep Research initiative, an advanced AI-powered m
 - [Release Checklist](docs/meta/release_checklist_v3.5.md) - Process for new releases
 - [Changelog](CHANGELOG.md) - Version history and changes
 
-
 ## 📂 Repository Structure (v3.5.3)
 ├── .github/               # GitHub configuration and workflows
 │   └── workflows/
@@ -118,6 +117,7 @@ This repository includes GitHub Actions workflows that automatically validate:
 - CHANGELOG format
 
 To run validations locally:
+
 ```bash
 # Install dependencies (one time)
 ./scripts/setup_env.sh
@@ -131,6 +131,7 @@ grep -r "TODO\|Coming soon" --include="*.md" --include="*.json" --include="*.yml
 
 ### For Developers
 1. Clone this repository:
+
    ```bash
    git clone https://github.com/adv-ai/o3-deep-research-context.git
    ```

--- a/docs/legacy/prompt/prompt_kernel_v3.4.md
+++ b/docs/legacy/prompt/prompt_kernel_v3.4.md
@@ -90,7 +90,7 @@ Answer the foundational research question:
 
 ---
 
-## 🧠 THINK LIKE:
+## 🧠 THINK LIKE
 
 * **Systems Architect** — design robust, modular, and scalable agent flows
 * **PromptOps Engineer** — enforce pattern reuse, token optimization, and lifecycle alignment

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,1 +1,17 @@
 # Utility Scripts
+
+This directory contains helper scripts for local development.
+
+- `setup_env.sh` installs markdownlint, jq, and yamllint so you can run checks locally.
+
+  ```bash
+  ./scripts/setup_env.sh
+  ```
+
+- `validate_golden_prompts.sh` validates the golden prompt files.
+
+  ```bash
+  bash scripts/validate_golden_prompts.sh
+  ```
+
+These steps mirror the CI pipeline to help ensure consistency.

--- a/scripts/validate_golden_prompts.sh
+++ b/scripts/validate_golden_prompts.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 echo "Validating golden prompts..."
 for file in tests/golden_prompts/*.md; do
+  [ "$(basename "$file")" = "README.md" ] && continue
   echo "Checking $file"
   for section in INPUT EXPECTED NOTES; do
     if ! grep -q "^### $section" "$file"; then

--- a/src/README.md
+++ b/src/README.md
@@ -1,1 +1,9 @@
-# Source Code
+# Source Code Examples
+
+This directory contains minimal agent implementations used for documentation and testing.
+
+- `base_agent.py` – shared base class for simple agents
+- `sample_agent.py` – toy example that echoes user input
+- `research_agent.py` – stub agent that returns placeholder research results
+
+Additional agents can be added following this pattern to experiment with the O3 Deep Research workflow.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,5 @@
+from .base_agent import BaseAgent
+from .sample_agent import EchoAgent
+from .research_agent import ResearchAgent
+
+__all__ = ["BaseAgent", "EchoAgent", "ResearchAgent"]

--- a/src/base_agent.py
+++ b/src/base_agent.py
@@ -1,0 +1,9 @@
+class BaseAgent:
+    """Minimal base class for demonstration."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def run(self, message: str) -> str:
+        """Process a message and return a response."""
+        raise NotImplementedError("Agents must implement run()")

--- a/src/research_agent.py
+++ b/src/research_agent.py
@@ -1,0 +1,20 @@
+try:
+    from .base_agent import BaseAgent
+except ImportError:  # Fallback for running as a script
+    from base_agent import BaseAgent
+
+
+class ResearchAgent(BaseAgent):
+    """Basic research agent stub."""
+
+    def __init__(self, name: str = "ResearchAgent") -> None:
+        super().__init__(name)
+
+    def run(self, query: str) -> str:
+        """Return a placeholder research result."""
+        return f"{self.name} results for '{query}'"
+
+
+if __name__ == "__main__":
+    agent = ResearchAgent()
+    print(agent.run("market trends"))

--- a/src/sample_agent.py
+++ b/src/sample_agent.py
@@ -1,0 +1,14 @@
+class EchoAgent:
+    """Simple agent that echoes received messages."""
+
+    def __init__(self, name: str = "EchoAgent") -> None:
+        self.name = name
+
+    def run(self, message: str) -> str:
+        """Return a formatted echo response."""
+        return f"{self.name}: {message}"
+
+
+if __name__ == "__main__":
+    agent = EchoAgent()
+    print(agent.run("Hello world"))

--- a/tests/golden_prompts/README.md
+++ b/tests/golden_prompts/README.md
@@ -15,9 +15,9 @@ Golden prompts are used to:
 
 | File | Purpose | Key Features Tested |
 |------|---------|-------------------|
-| `test_prompt_coordinator.md` | Validates multi-agent coordination and ReAct patterns | - Agent communication<br>- ReAct-style reasoning<br>- Feedback loops |
-| `test_memory_reflection.md`  | Tests memory retrieval and meta-reflection capabilities | - Memory access<br>- Reflection loops<br>- Performance learning |
-| `test_kpi_optimization.md`   | Validates KPI-driven optimization strategies | - KPI tracking<br>- Content strategy<br>- Performance optimization |
+| `test_prompt_coordinator.md` | Validates multi-agent coordination and ReAct patterns | Agent communication; ReAct-style reasoning; Feedback loops |
+| `test_memory_reflection.md`  | Tests memory retrieval and meta-reflection capabilities | Memory access; Reflection loops; Performance learning |
+| `test_kpi_optimization.md`   | Validates KPI-driven optimization strategies | KPI tracking; Content strategy; Performance optimization |
 
 ## Usage
 
@@ -48,44 +48,8 @@ When adding new golden prompts:
 3. Add relevant tags
 4. Update this README
 5. Ensure CI passes
-### -INPUT
-Example placeholder for CI validation.
-
-### -EXPECTED
-This README file passes section checks.
-
-### -NOTES
-Demonstration of required headers.
-
-**Tags:** example
-
-
-### -INPUT
-N/A
-
-### -EXPECTED
-N/A
-
-### -NOTES
-Prompt Kernel: v3.5
-**Tags:** documentation
-
 ## Related Documentation
 
 - [Prompt Kernel v3.5 Documentation](./../../docs/prompt/prompt_kernel_v3.5.md)
 - [Testing Guidelines](../../docs/contribution_guide.md)
 - [CI Configuration](./../../.github/workflows/validate_repo.yml)
-
-### INPUT
-
-Placeholder for validation.
-
-### EXPECTED
-
-Placeholder for validation.
-
-### NOTES
-
-Placeholder for validation.
-
-**Tags:** placeholder

--- a/tests/golden_prompts/test_kpi_optimization.md
+++ b/tests/golden_prompts/test_kpi_optimization.md
@@ -1,12 +1,15 @@
-### -INPUT
+# KPI Optimization
+<!-- markdownlint-disable MD001 -->
+
+### INPUT
 Suggest a content strategy to maximize click-through rate (CTR) for a B2B SaaS product, considering user funnel stages.
 
-### -EXPECTED
+### EXPECTED
 - Segments user journey (TOFU / MOFU / BOFU)
 - Matches content type to stage (e.g., webinar for MOFU)
 - Optimizes CTA phrasing based on CTR patterns
 - Shows alignment with `Prompt Kernel v3.5` architecture map
 
-### -NOTES
+### NOTES
 Prompt Kernel: v3.5  
 **Tags:** KPI optimization, content strategy, content targeting

--- a/tests/golden_prompts/test_memory_reflection.md
+++ b/tests/golden_prompts/test_memory_reflection.md
@@ -1,12 +1,15 @@
-### -INPUT
+# Memory Reflection
+<!-- markdownlint-disable MD001 -->
+
+### INPUT
 What insights can be retrieved from past performance data to improve this quarter's PPC planning?
 
-### -EXPECTED
+### EXPECTED
 - MemoryAgent fetches campaign summary or KPI trends
 - Mentions meta-reflection mechanism (e.g., `BEGIN_REFLECTION`)
 - Suggests a change in targeting or budget allocation
 - Cites "ROI loop" or historical learning data
 
-### -NOTES
+### NOTES
 Prompt Kernel: v3.5
 **Tags:** memory retrieval, meta-reflection loop, performance learning

--- a/tests/golden_prompts/test_prompt_coordinator.md
+++ b/tests/golden_prompts/test_prompt_coordinator.md
@@ -1,14 +1,17 @@
-### -INPUT
+# Prompt Coordinator
+<!-- markdownlint-disable MD001 -->
+
+### INPUT
 Act as a research agent coordinating with campaign and memory agents to optimize a digital ad strategy. Include ReAct-style reasoning and trigger a feedback loop.
 
-### -EXPECTED
+### EXPECTED
 
 - Uses ReAct-style prompt chaining (`THOUGHT → ACTION → OBSERVATION`)
 - Shows message from MemoryAgent to refine parameters
 - Campaign strategy includes channel choice + timing
 - Ends with meta-reflection and optimization loop
 
-### -NOTES
+### NOTES
 Prompt Kernel: v3.5
 
 **Tags:** multi-agent coordination, ReAct


### PR DESCRIPTION
## Summary
- skip README when validating golden prompts
- align CI with local golden prompt script
- expand script documentation
- trim example block from golden prompt README
- add base and research agent stubs

## Testing
- `npx markdownlint-cli2 '**/*.md'`
- `bash scripts/validate_golden_prompts.sh`
- `python3 src/sample_agent.py`
- `python3 src/research_agent.py`
- `PYTHONPATH=src python3 - <<'PY'
from research_agent import ResearchAgent
print(ResearchAgent().run('demo'))
PY`