### PR TITLE
feat(sources): add 24 external documentation references

### DIFF
--- a/docs/external/a2a_protocol.md
+++ b/docs/external/a2a_protocol.md
@@ -1,0 +1,15 @@
+# A2A Protocol
+
+**URL:** https://github.com/AutogenStudio/autogen  
+**Relevance:** coordination, orchestration  
+**Used by Agents:** ConfigAgent, CampaignAgent
+
+## Description
+The A2A (Agent-to-Agent) protocol defines a standard for multi-agent communication and coordination. It enables reliable message passing and task delegation among autonomous agents.
+
+## Use Cases
+- Implement structured agent collaboration workflows
+- Share state between orchestrated micro-agents
+
+## Integration Ideas
+- Extend ADK agents with A2A-compatible endpoints

--- a/docs/external/ai_fairness_360_toolkit.md
+++ b/docs/external/ai_fairness_360_toolkit.md
@@ -1,0 +1,15 @@
+# AI Fairness 360 Toolkit
+
+**URL:** https://aif360.readthedocs.io/  
+**Relevance:** bias, scoring  
+**Used by Agents:** AnalyticsAgent, ConfigAgent
+
+## Description
+IBM's AI Fairness 360 Toolkit provides metrics and algorithms to detect and mitigate bias in AI models.
+
+## Use Cases
+- Audit prompts for potential bias
+- Compare fairness metrics across models
+
+## Integration Ideas
+- Integrate bias checks into evaluation pipelines

--- a/docs/external/airtable_api.md
+++ b/docs/external/airtable_api.md
@@ -1,0 +1,15 @@
+# Airtable API
+
+**URL:** https://airtable.com/developers/web/api/introduction  
+**Relevance:** memory, coordination  
+**Used by Agents:** ResearchAgent, ConfigAgent
+
+## Description
+Airtable's API allows structured data storage with spreadsheet-like ease. ADK agents can use it to persist results and share records across workflows.
+
+## Use Cases
+- Store research notes and evaluation metrics
+- Manage configuration tables for prompts
+
+## Integration Ideas
+- Sync airtable bases with agent memory modules

--- a/docs/external/amplitude_docs.md
+++ b/docs/external/amplitude_docs.md
@@ -1,0 +1,15 @@
+# Amplitude Docs
+
+**URL:** https://www.docs.developers.amplitude.com  
+**Relevance:** analytics, performance  
+**Used by Agents:** AnalyticsAgent, OptimizationAgent
+
+## Description
+Amplitude provides product analytics for measuring user engagement and conversion. Their developer docs outline APIs for ingesting events and querying insights.
+
+## Use Cases
+- Track agent-driven funnel metrics
+- Analyze prompt impact on user behavior
+
+## Integration Ideas
+- Automate data exports for model performance monitoring

--- a/docs/external/anthropic_prompting_guide.md
+++ b/docs/external/anthropic_prompting_guide.md
@@ -1,0 +1,15 @@
+# Anthropic Prompting Guide
+
+**URL:** https://docs.anthropic.com/claude/prompting-best-practices  
+**Relevance:** prompting, grounding  
+**Used by Agents:** ResearchAgent, ContentAgent
+
+## Description
+Anthropic's guide outlines best practices for constructing prompts with Claude, including chain-of-thought, embedding usage, and framing techniques.
+
+## Use Cases
+- Improve reasoning quality in Claude-based prompts
+- Establish consistent style guidelines
+
+## Integration Ideas
+- Incorporate these patterns into agent prompt templates

--- a/docs/external/apple_ml_apis.md
+++ b/docs/external/apple_ml_apis.md
@@ -1,0 +1,15 @@
+# Apple ML APIs
+
+**URL:** https://developer.apple.com/machine-learning/  
+**Relevance:** fallback, on-device  
+**Used by Agents:** EngagementAgent
+
+## Description
+Apple's machine learning APIs offer tools for deploying models on iOS and macOS with privacy-focused approaches.
+
+## Use Cases
+- Run local inference for user interactions
+- Ensure data stays on-device for sensitive workflows
+
+## Integration Ideas
+- Evaluate Core ML for offline prompt evaluation

--- a/docs/external/claude_api_docs.md
+++ b/docs/external/claude_api_docs.md
@@ -1,0 +1,15 @@
+# Claude API Docs
+
+**URL:** https://docs.anthropic.com  
+**Relevance:** prompting, grounding, fallback  
+**Used by Agents:** ContentAgent, ConfigAgent, ResearchAgent
+
+## Description
+Official documentation for the Anthropic Claude API, covering endpoints, prompt guidelines, and response formats.
+
+## Use Cases
+- Evaluate Claude as an alternative inference model
+- Compare prompt best practices across providers
+
+## Integration Ideas
+- Build fallback routines to Claude for reliability

--- a/docs/external/cognitive_load_design.md
+++ b/docs/external/cognitive_load_design.md
@@ -1,0 +1,15 @@
+# CognitiveLoad Design (NNG)
+
+**URL:** https://www.nngroup.com/topic/cognitive-load/  
+**Relevance:** behavioral prompting  
+**Used by Agents:** EngagementAgent, ContentAgent
+
+## Description
+Nielsen Norman Group's research on cognitive load informs how to design experiences that account for user attention and effort.
+
+## Use Cases
+- Optimize prompts for minimal cognitive overhead
+- Tailor engagement tactics to user capacity
+
+## Integration Ideas
+- Apply cognitive principles to conversation flows

--- a/docs/external/fastapi_docs.md
+++ b/docs/external/fastapi_docs.md
@@ -1,0 +1,15 @@
+# FastAPI Docs
+
+**URL:** https://fastapi.tiangolo.com/  
+**Relevance:** api, coordination  
+**Used by Agents:** All agents
+
+## Description
+FastAPI is a modern web framework for building APIs with Python. It provides asynchronous request handling and automatic documentation.
+
+## Use Cases
+- Create lightweight endpoints to connect agents
+- Build microservices for prompt orchestration
+
+## Integration Ideas
+- Wrap agent functions as FastAPI routes for interop

--- a/docs/external/flan_t5_prompt_patterns.md
+++ b/docs/external/flan_t5_prompt_patterns.md
@@ -1,0 +1,15 @@
+# FLAN-T5 Prompt Patterns
+
+**URL:** https://github.com/google-research/FLAN  
+**Relevance:** task grounding  
+**Used by Agents:** ResearchAgent
+
+## Description
+FLAN-T5 examples highlight cross-task generalization and demonstrate how prompts map to various downstream tasks.
+
+## Use Cases
+- Reference multimodal examples for new tasks
+- Adapt patterns to specialized domains
+
+## Integration Ideas
+- Expand agent capabilities with FLAN-style templates

--- a/docs/external/gdpr_prompting_compliance.md
+++ b/docs/external/gdpr_prompting_compliance.md
@@ -1,0 +1,15 @@
+# GDPR Prompting Compliance
+
+**URL:** https://gdpr.eu  
+**Relevance:** compliance, constraints  
+**Used by Agents:** EngagementAgent, ConfigAgent
+
+## Description
+GDPR resources provide guidelines on data privacy and consent requirements that impact conversational AI and user messaging.
+
+## Use Cases
+- Ensure prompts and data handling meet regulatory obligations
+- Reference consent language for user interactions
+
+## Integration Ideas
+- Bake compliance checks into agent message templates

--- a/docs/external/google_docs_api.md
+++ b/docs/external/google_docs_api.md
@@ -1,0 +1,17 @@
+# Google Docs API
+
+**URL:** https://developers.google.com/docs  
+**Relevance:** memory, grounding, coordination  
+**Used by Agents:** ResearchAgent, ConfigAgent, ContentAgent
+
+## Description
+Google Docs API enables structured document creation, formatting, and semantic content generation from code. In the context of ADK agent workflows, it can act as both a **semantic memory channel** and **document-based orchestration endpoint**.
+
+## Use Cases
+- Embed prompt outputs into live docs (ContentAgent)
+- Extract signal/summary from shared knowledge (ResearchAgent)
+- Configure contextual schemas (ConfigAgent)
+
+## Integration Ideas
+- Use as write memory for engagement feedback
+- Leverage JSON-based doc templates for routing metadata

--- a/docs/external/gopher_prompt_lab.md
+++ b/docs/external/gopher_prompt_lab.md
@@ -1,0 +1,15 @@
+# DeepMind Gopher Prompt Lab
+
+**URL:** https://arxiv.org/abs/2202.11382  
+**Relevance:** reflection, mutation  
+**Used by Agents:** CampaignAgent, ConfigAgent
+
+## Description
+The Gopher Prompt Lab paper explores methods for reasoning, scoring, and prompt mutation to achieve better LLM responses.
+
+## Use Cases
+- Experiment with scoring-driven prompt evolution
+- Study reasoning frameworks applicable to multi-agent setups
+
+## Integration Ideas
+- Apply mutation strategies to refine campaign prompts

--- a/docs/external/helm_charts_docs.md
+++ b/docs/external/helm_charts_docs.md
@@ -1,0 +1,15 @@
+# Helm Charts (K8s)
+
+**URL:** https://helm.sh/docs/  
+**Relevance:** deployment, CI/CD  
+**Used by Agents:** ConfigAgent, Infra
+
+## Description
+Helm is a package manager for Kubernetes that simplifies deployment of complex applications using chart templates.
+
+## Use Cases
+- Deploy agent stacks on Kubernetes clusters
+- Version infrastructure alongside code
+
+## Integration Ideas
+- Provide Helm charts for replicating ADK deployments

--- a/docs/external/langchain_docs.md
+++ b/docs/external/langchain_docs.md
@@ -1,0 +1,15 @@
+# LangChain Docs
+
+**URL:** https://docs.langchain.com  
+**Relevance:** prompting, coordination, memory  
+**Used by Agents:** ConfigAgent, ResearchAgent
+
+## Description
+LangChain provides modular utilities for building language model powered applications. ADK agents can leverage these components for chaining tasks and managing context windows.
+
+## Use Cases
+- Experiment with chain-of-thought pipelines
+- Manage conversation history across tools
+
+## Integration Ideas
+- Prototype new agent workflows using LangChain abstractions

--- a/docs/external/mcp_server_api.md
+++ b/docs/external/mcp_server_api.md
@@ -1,0 +1,15 @@
+# MCP Server API
+
+**URL:** https://mcp-docs.readthedocs.io/  
+**Relevance:** orchestration, memory  
+**Used by Agents:** ConfigAgent, Infra
+
+## Description
+The MCP Server API exposes endpoints for storing, retrieving, and managing agent data across distributed services.
+
+## Use Cases
+- Centralize logs and metrics from multiple agents
+- Retrieve shared configuration values
+
+## Integration Ideas
+- Use as a persistent memory layer for agent state

--- a/docs/external/mlflow_docs.md
+++ b/docs/external/mlflow_docs.md
@@ -1,0 +1,15 @@
+# MLflow
+
+**URL:** https://mlflow.org/docs/latest/index.html  
+**Relevance:** prompt lineage, tuning  
+**Used by Agents:** AnalyticsAgent, OptimizationAgent
+
+## Description
+MLflow is a platform for managing the end-to-end machine learning lifecycle, including experiment tracking and model registry.
+
+## Use Cases
+- Log prompt versions and metrics
+- Track experiments for tuning strategies
+
+## Integration Ideas
+- Store evaluation results alongside model artifacts

--- a/docs/external/n8n_docs.md
+++ b/docs/external/n8n_docs.md
@@ -1,0 +1,15 @@
+# n8n Docs
+
+**URL:** https://docs.n8n.io  
+**Relevance:** coordination, automation  
+**Used by Agents:** ConfigAgent, IntegrationAgent
+
+## Description
+n8n is a workflow automation tool with a node-based interface and rich API. Its documentation provides guidelines for integrating external services.
+
+## Use Cases
+- Trigger agent actions via webhooks and workflows
+- Connect ADK tasks with third-party APIs
+
+## Integration Ideas
+- Build low-code orchestrations between data sources and agents

--- a/docs/external/openai_cookbook.md
+++ b/docs/external/openai_cookbook.md
@@ -1,0 +1,15 @@
+# OpenAI Cookbook
+
+**URL:** https://github.com/openai/openai-cookbook  
+**Relevance:** prompting, memory, fallback  
+**Used by Agents:** ResearchAgent, ContentAgent
+
+## Description
+The OpenAI Cookbook contains practical examples and code snippets for using OpenAI models effectively. It offers recipes for prompt engineering, embedding usage, and data pipelines.
+
+## Use Cases
+- Reference best practices for prompt formatting
+- Learn advanced API patterns for retrieval and summarization
+
+## Integration Ideas
+- Adapt sample notebooks to benchmark agent behaviors

--- a/docs/external/openprompt_evaluator.md
+++ b/docs/external/openprompt_evaluator.md
@@ -1,0 +1,15 @@
+# OpenPrompt Evaluator
+
+**URL:** https://github.com/thunlp/OpenPrompt  
+**Relevance:** validation, scoring  
+**Used by Agents:** ConfigAgent, PromptOps
+
+## Description
+OpenPrompt provides a framework for comparing prompt versions and evaluating language model outputs.
+
+## Use Cases
+- Benchmark different prompting techniques
+- Integrate continuous evaluation in CI
+
+## Integration Ideas
+- Build automated tests for prompt regressions

--- a/docs/external/ray_serve_docs.md
+++ b/docs/external/ray_serve_docs.md
@@ -1,0 +1,15 @@
+# Ray Serve Docs
+
+**URL:** https://docs.ray.io/en/latest/serve/  
+**Relevance:** orchestration, performance  
+**Used by Agents:** ConfigAgent, CampaignAgent
+
+## Description
+Ray Serve provides scalable microservice orchestration for deploying machine learning models and agents.
+
+## Use Cases
+- Deploy agent inference services with autoscaling
+- Coordinate distributed workloads across nodes
+
+## Integration Ideas
+- Combine Ray Serve with ADK to host specialized agent endpoints

--- a/docs/external/tinyml_edge_ai.md
+++ b/docs/external/tinyml_edge_ai.md
@@ -1,0 +1,15 @@
+# TinyML / Edge AI
+
+**URL:** https://www.tinyml.org/  
+**Relevance:** adaptive control, fallback  
+**Used by Agents:** OptimizationAgent, ConfigAgent
+
+## Description
+TinyML explores machine learning techniques for resource-constrained devices, enabling on-device inference and quick adaptation.
+
+## Use Cases
+- Tune agent parameters locally for privacy
+- Handle fallback logic when cloud access is limited
+
+## Integration Ideas
+- Investigate lightweight models for edge deployments

--- a/docs/external/vertex_ai_grounding.md
+++ b/docs/external/vertex_ai_grounding.md
@@ -1,0 +1,15 @@
+# Vertex AI Grounding
+
+**URL:** https://cloud.google.com/vertex-ai/docs/generative-ai/grounding  
+**Relevance:** grounding, prompting  
+**Used by Agents:** ResearchAgent, ContentAgent
+
+## Description
+Vertex AI Grounding describes how to anchor generative outputs to trusted data sources using Google Cloud services.
+
+## Use Cases
+- Improve factual accuracy via retrieval and grounding
+- Connect custom databases to agent workflows
+
+## Integration Ideas
+- Explore integrated RAG pipelines with Vertex AI features

--- a/docs/external/weights_and_biases_docs.md
+++ b/docs/external/weights_and_biases_docs.md
@@ -1,0 +1,15 @@
+# Weights & Biases Docs
+
+**URL:** https://docs.wandb.ai/  
+**Relevance:** CI, metrics, tuning  
+**Used by Agents:** ConfigAgent, AnalyticsAgent
+
+## Description
+Weights & Biases provides experiment tracking and visualization tools for machine learning and prompt development.
+
+## Use Cases
+- Monitor prompt performance across iterations
+- Visualize agent metrics in real-time dashboards
+
+## Integration Ideas
+- Integrate W&B runs to track agent optimization trials

--- a/docs/source_index.json
+++ b/docs/source_index.json
@@ -280,11 +280,230 @@
       ],
       "version": "3.5.4",
       "type": "documentation"
+    },
+    {
+      "name": "Google Docs API",
+      "link": "https://developers.google.com/docs",
+      "tags": [
+        "memory",
+        "grounding",
+        "coordination"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "LangChain Docs",
+      "link": "https://docs.langchain.com",
+      "tags": [
+        "prompting",
+        "coordination",
+        "memory"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "OpenAI Cookbook",
+      "link": "https://github.com/openai/openai-cookbook",
+      "tags": [
+        "prompting",
+        "memory",
+        "fallback"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "Claude API Docs",
+      "link": "https://docs.anthropic.com",
+      "tags": [
+        "prompting",
+        "grounding",
+        "fallback"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "A2A Protocol",
+      "link": "https://github.com/AutogenStudio/autogen",
+      "tags": [
+        "coordination",
+        "orchestration"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "n8n Docs",
+      "link": "https://docs.n8n.io",
+      "tags": [
+        "coordination",
+        "automation"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "MCP Server API",
+      "link": "https://mcp-docs.readthedocs.io/",
+      "tags": [
+        "orchestration",
+        "memory"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "Airtable API",
+      "link": "https://airtable.com/developers/web/api/introduction",
+      "tags": [
+        "memory",
+        "coordination"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "Vertex AI Grounding",
+      "link": "https://cloud.google.com/vertex-ai/docs/generative-ai/grounding",
+      "tags": [
+        "grounding",
+        "prompting"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "Amplitude Docs",
+      "link": "https://www.docs.developers.amplitude.com",
+      "tags": [
+        "analytics",
+        "performance"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "Ray Serve Docs",
+      "link": "https://docs.ray.io/en/latest/serve/",
+      "tags": [
+        "orchestration",
+        "performance"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "MLflow",
+      "link": "https://mlflow.org/docs/latest/index.html",
+      "tags": [
+        "prompt lineage",
+        "tuning"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "Weights & Biases Docs",
+      "link": "https://docs.wandb.ai/",
+      "tags": [
+        "CI",
+        "metrics",
+        "tuning"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "FastAPI Docs",
+      "link": "https://fastapi.tiangolo.com/",
+      "tags": [
+        "api",
+        "coordination"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "Helm Charts (K8s)",
+      "link": "https://helm.sh/docs/",
+      "tags": [
+        "deployment",
+        "CI/CD"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "Anthropic Prompting Guide",
+      "link": "https://docs.anthropic.com/claude/prompting-best-practices",
+      "tags": [
+        "prompting",
+        "grounding"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "DeepMind Gopher Prompt Lab",
+      "link": "https://arxiv.org/abs/2202.11382",
+      "tags": [
+        "reflection",
+        "mutation"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "FLAN-T5 Prompt Patterns",
+      "link": "https://github.com/google-research/FLAN",
+      "tags": [
+        "task grounding"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "CognitiveLoad Design",
+      "link": "https://www.nngroup.com/topic/cognitive-load/",
+      "tags": [
+        "behavioral prompting"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "TinyML / Edge AI",
+      "link": "https://www.tinyml.org/",
+      "tags": [
+        "adaptive control",
+        "fallback"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "Apple ML APIs",
+      "link": "https://developer.apple.com/machine-learning/",
+      "tags": [
+        "fallback",
+        "on-device"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "AI Fairness 360 Toolkit",
+      "link": "https://aif360.readthedocs.io/",
+      "tags": [
+        "bias",
+        "scoring"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "GDPR Prompting Compliance",
+      "link": "https://gdpr.eu",
+      "tags": [
+        "compliance",
+        "constraints"
+      ],
+      "type": "external"
+    },
+    {
+      "name": "OpenPrompt Evaluator",
+      "link": "https://github.com/thunlp/OpenPrompt",
+      "tags": [
+        "validation",
+        "scoring"
+      ],
+      "type": "external"
     }
   ],
   "metadata": {
     "include_web": true,
-    "last_updated": "2025-05-25",
+    "last_updated": "2025-05-29",
     "version": "3.5.4"
   }
 }

--- a/meta/source_integration_log.md
+++ b/meta/source_integration_log.md
@@ -1,0 +1,30 @@
+## [2025-05-29] External Source Integration – Prompted by PROMPTFORGE
+
+Integrated the following 24 sources into `/docs/source_index.json` and created `.md` stubs in `/docs/external/`:
+
+- Google Docs API
+- LangChain Docs
+- OpenAI Cookbook
+- Claude API Docs
+- A2A Protocol
+- n8n Docs
+- MCP Server API
+- Airtable API
+- Vertex AI Grounding
+- Amplitude Docs
+- Ray Serve Docs
+- MLflow
+- Weights & Biases Docs
+- FastAPI Docs
+- Helm Charts (K8s)
+- Anthropic Prompting Guide
+- DeepMind Gopher Prompt Lab
+- FLAN-T5 Prompt Patterns
+- CognitiveLoad Design
+- TinyML / Edge AI
+- Apple ML APIs
+- AI Fairness 360 Toolkit
+- GDPR Prompting Compliance
+- OpenPrompt Evaluator
+
+Codex Commit: `feat(sources): added external documentation references`


### PR DESCRIPTION
## Summary
- add documentation stubs for 24 new external sources in `docs/external/`
- register these sources in `docs/source_index.json`
- log integration in `meta/source_integration_log.md`

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" "\!docs/legacy/**"`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}' .`
- `bash scripts/validate_golden_prompts.sh`
- `curl` link check *(fails: Could not resolve host)*