### PR TITLE
Improve docs and tests per May notes

### DIFF
--- a/docs/agent_system_overview.md
+++ b/docs/agent_system_overview.md
@@ -68,4 +68,6 @@ used by more advanced agents.
 - **Phase 3: Self-Tuning and Scaling (6–12 months)** – Add ConfigAgent and automated prompt evolution across all agents.
 
 ## Diagrams
-See architectural diagrams in [prompt kernel](prompt/prompt_kernel_v3.5.md#module-map).
+The 21 May prompt introduced a sequential flow diagram showing Research → Content → Campaign → Optimization → Analytics. See the [prompt kernel](prompt/prompt_kernel_v3.5.md#module-map) for visuals.
+
+For connection instructions refer to the [Integration Guide](integration_guide_o3.md).

--- a/docs/governance_agent_overview.md
+++ b/docs/governance_agent_overview.md
@@ -1,6 +1,6 @@
 # GovernanceAgent Concept
 
-The **GovernanceAgent** is a proposed supervisory layer that monitors other agents and enforces compliance rules.
+The **GovernanceAgent** acts as a supervisory layer that monitors all other agents, enforces compliance rules, and handles escalation.
 
 ## Purpose
 - Track agent heartbeats and trigger alerts on failure
@@ -15,4 +15,14 @@ if not agent_heartbeat.ok:
 
 ```
 
-This agent would integrate with the coordination bus and provide audit logs for all escalations.
+### Coordination Integration
+
+The GovernanceAgent listens on the same Pub/Sub bus used for inter-agent messages. It emits `heartbeat_check` requests and expects a timely `heartbeat_ack` from each agent. Missing acknowledgments trigger a retry and potential escalation.
+
+### Retry & Escalation Flow
+
+1. Send `heartbeat_check` to target agent
+2. Wait up to 30 seconds for `heartbeat_ack`
+3. If no response, retry twice then send an `escalate` message to the strategist
+
+All escalation events are captured in a persistent audit log. Example entries are shown in the [72-hour simulation](simulations/72hr_campaign_sim.md#sample-log-snippet).

--- a/docs/meta/prompt_evolution_log/v3.5.yaml
+++ b/docs/meta/prompt_evolution_log/v3.5.yaml
@@ -7,5 +7,7 @@ subversions:
     summary: added integration guide and minor docs
   - tag: 3.5.3
     summary: expanded agent overview and simulation docs
+  - tag: 3.5.4
+    summary: governance agent concept and routing diff tests
 notes:
   - 'Version 3.5.4 introduces config mutation tests and governance concept.'

--- a/docs/meta/version_diff_v3.5.3_to_v3.5.4.md
+++ b/docs/meta/version_diff_v3.5.3_to_v3.5.4.md
@@ -1,0 +1,14 @@
+# Version Diff: v3.5.3 → v3.5.4
+
+This document highlights the incremental updates introduced in subversion 3.5.4 of the O3 Deep Research prompt system.
+
+## Key Updates
+- Added GovernanceAgent overview with heartbeat and escalation flow
+- Extended 72‑hour simulation with log examples and failure recovery steps
+- Introduced routing diff golden prompt for ConfigAgent testing
+
+## Impact
+- **Documentation**: clearer recovery scenarios and governance integration
+- **Testing**: additional golden prompt improves config validation
+
+No breaking changes were introduced. Projects using v3.5.3 can upgrade seamlessly to v3.5.4.

--- a/docs/prompt/prompt_kernel_v3.5.md
+++ b/docs/prompt/prompt_kernel_v3.5.md
@@ -6,7 +6,7 @@ ROLE: You are **O3 Deep Research** — an elite, autonomous research agent speci
 ## 📍 CONTEXT
 
 * Company: ADV IT Performance Corp. ([https://adv-it-performance.ca](https://adv-it-performance.ca), [https://adv-it-performance.dev](https://adv-it-performance.dev))
-nFor repository integration steps see [Integration Guide](../integration_guide_o3.md).
+For repository integration steps see [Integration Guide](../integration_guide_o3.md).
 
 * Industry: PPC performance marketing, digital marketing automation
 * Vision: Create an intelligent multi-agent system that automates the full digital marketing lifecycle:
@@ -706,3 +706,5 @@ Next steps include:
 3. Training initial models with specific marketing data
 4. Running controlled pilot campaigns
 5. Full deployment with monitoring and feedback collection
+
+For repository connection and usage details see the [Integration Guide](../integration_guide_o3.md).

--- a/docs/simulations/72hr_campaign_sim.md
+++ b/docs/simulations/72hr_campaign_sim.md
@@ -54,4 +54,18 @@ This document outlines a simulated 72-hour PPC campaign lifecycle to test and va
 |-----------|-------|-----------------|
 | Day 1 14:00 | Ad disapproval on Meta | GovernanceAgent triggers policy audit; CampaignAgent swaps creative |
 | Day 2 09:30 | API timeout fetching metrics | OptimizationAgent retries after 5 minutes and logs warning |
+| Day 2 17:15 | LinkedIn CTR < 0.5% | OptimizationAgent disables underperforming ad set and reallocates budget |
+| Day 3 08:00 | Cost spike detected | CampaignAgent lowers bids and pings GovernanceAgent for review |
 | Day 3 16:45 | ROAS drop > 20% | ConfigAgent rolls back to previous prompt version and notifies strategist |
+
+See [GovernanceAgent Overview](../governance_agent_overview.md) for escalation logic details.
+
+## Sample Log Snippet
+
+```text
+2025-05-21T14:00Z GovernanceAgent  policy_audit triggered on Meta ad disapproval
+2025-05-22T09:30Z OptimizationAgent retry metrics fetch (attempt=2)
+2025-05-22T17:15Z OptimizationAgent disabled LinkedIn ad set #32 due to low CTR
+2025-05-23T08:00Z CampaignAgent reduced bids by 15% after cost spike
+2025-05-23T16:45Z ConfigAgent restored prompt v3.5.3 and notified strategist
+```

--- a/tests/golden_prompts/README.md
+++ b/tests/golden_prompts/README.md
@@ -19,6 +19,7 @@ Golden prompts are used to:
 | `test_memory_reflection.md`  | Tests memory retrieval and meta-reflection capabilities | Memory access; Reflection loops; Performance learning |
 | `test_kpi_optimization.md`   | Validates KPI-driven optimization strategies | KPI tracking; Content strategy; Performance optimization |
 | `test_config_adjustment.md`  | Tests configuration updates and schema diffs | ConfigAgent validation; Self-reflection |
+| `test_config_routing_diff.md` | Validates routing table adjustments | ConfigAgent diff summary; Alert routing |
 
 ## Usage
 

--- a/tests/golden_prompts/test_config_routing_diff.md
+++ b/tests/golden_prompts/test_config_routing_diff.md
@@ -1,0 +1,14 @@
+# Config Routing Diff
+<!-- markdownlint-disable MD001 -->
+
+### INPUT
+ConfigAgent receives a new routing table with updated weights. Provide a summary diff and alert via `config_push`.
+
+### EXPECTED
+- Outputs YAML diff highlighting weight changes
+- Sends `config_push` message noting version 3.5.4
+- Mentions validation checklist
+
+### NOTES
+Prompt Kernel: v3.5.4
+**Tags:** config-agent, routing-diff


### PR DESCRIPTION
## Summary
- extend 72h simulation with extra failure recovery and log snippet
- elaborate on GovernanceAgent heartbeat and escalation
- document routing diff prompt and update golden prompt list
- cross-link integration guide from prompt kernel and overview
- record version diff for v3.5.3 -> v3.5.4 and update evolution log

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" "tests/golden_prompts/*.md"`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}' docs/meta/prompt_evolution_log/v3.5.yaml`
- `bash scripts/validate_golden_prompts.sh`
- `bash scripts/offline_link_check.sh`